### PR TITLE
Added clarifying text for DEV-27, DEV-28 & DEV-29

### DIFF
--- a/asciidoc/volume2/dev-27/tf2-dev-27.adoc
+++ b/asciidoc/volume2/dev-27/tf2-dev-27.adoc
@@ -56,6 +56,7 @@ include::../../plantuml/vol2-figure-dev-27-sequence.puml[]
 
 // ---------- SUBSCRIBE ---------
 
+CAUTION: Transaction {var_transaction_id} supports a general <<vol2_clause_dev_27_message_notification>> message.  Specialized notification messages are detailed in <<vol2_clause_dev_28>> and <<vol2_clause_dev_29>>, based on payload content and trigger events.
 
 [#vol2_clause_dev_27_message_subscribe]
 ===== {var_label_dev_27_message_subscribe} Message

--- a/asciidoc/volume2/dev-28/tf2-dev-28.adoc
+++ b/asciidoc/volume2/dev-28/tf2-dev-28.adoc
@@ -42,6 +42,7 @@ include::../../plantuml/vol2-figure-dev-28-sequence.puml[]
 
 // ---------- EpisodicContextReport ---------
 
+CAUTION: Transaction {var_transaction_id} supports a specialized instance of the general <<vol2_clause_dev_27_message_notification>> message, based on payload content and trigger events.
 
 [#vol2_clause_dev_28_message_notification]
 ===== {var_label_dev_28_message_contextreport} Message

--- a/asciidoc/volume2/dev-29/tf2-dev-29.adoc
+++ b/asciidoc/volume2/dev-29/tf2-dev-29.adoc
@@ -42,6 +42,7 @@ include::../../plantuml/vol2-figure-dev-29-sequence.puml[]
 
 // ---------- Notification ---------
 
+CAUTION: Transaction {var_transaction_id} supports a specialized instance of the general <<vol2_clause_dev_27_message_notification>> message, based on payload content and trigger events.
 
 [#vol2_clause_dev_29_message_notification]
 ===== {var_label_dev_29_message_notification} Message


### PR DESCRIPTION
Added "caution" (flame) notes indicating the relationship between these three transactions and their "notification" messages.

Closes #75  
Closes #76 

## 📑 Description

Added "caution:" blocks to DEV-27, -28 & -29 regarding their use of notification() messages and how they are differentiated.

