### PR TITLE
Added PUML Diagrams to -R, -A, -xC

### DIFF
--- a/asciidoc/plantuml/vol1-figure-sdpi-a-delegation-example-sequence-diagram.puml
+++ b/asciidoc/plantuml/vol1-figure-sdpi-a-delegation-example-sequence-diagram.puml
@@ -1,7 +1,7 @@
 @startuml
 
-!global $str_sdc_sc = "SOMDS Consumer"
-!global $str_sdc_sp = "SOMDS Provider"
+!global $str_sdc_sc = "SOMDS Medical Alert Consumer"
+!global $str_sdc_sp = "SOMDS Medical Alert Provider"
 
 participant "$str_sdc_sc" as sdc_sc
 participant "$str_sdc_sp" as sdc_sp

--- a/asciidoc/plantuml/vol1-figure-sdpi-a-reporting-example-sequence-diagram.puml
+++ b/asciidoc/plantuml/vol1-figure-sdpi-a-reporting-example-sequence-diagram.puml
@@ -1,7 +1,7 @@
 @startuml
 
-!global $str_sdc_sc = "SOMDS Consumer"
-!global $str_sdc_sp = "SOMDS Provider"
+!global $str_sdc_sc = "SOMDS Medical Alert Consumer"
+!global $str_sdc_sp = "SOMDS Medical Alert Provider"
 
 participant "$str_sdc_sc" as sdc_sc
 participant "$str_sdc_sp" as sdc_sp

--- a/asciidoc/plantuml/vol1-figure-sdpi-r-example-sequence-diagram.puml
+++ b/asciidoc/plantuml/vol1-figure-sdpi-r-example-sequence-diagram.puml
@@ -3,8 +3,8 @@
 skinparam monochrome true
 autonumber
 
-!global $str_sdc_sc = "SOMDS Consumer"
-!global $str_sdc_sp = "SOMDS Provider"
+!global $str_sdc_sc = "SOMDS Medical Data Consumer"
+!global $str_sdc_sp = "SOMDS Medical Data Provider"
 
 participant "$str_sdc_sc" as sdc_sc
 participant "$str_sdc_sp" as sdc_sp

--- a/asciidoc/plantuml/vol1-figure-sdpi-xc-example-sequence-diagram.puml
+++ b/asciidoc/plantuml/vol1-figure-sdpi-xc-example-sequence-diagram.puml
@@ -3,8 +3,8 @@
 skinparam monochrome true
 autonumber
 
-!global $str_sdc_sc = "SOMDS Consumer"
-!global $str_sdc_sp = "SOMDS Provider"
+!global $str_sdc_sc = "SOMDS Medical Control Consumer"
+!global $str_sdc_sp = "SOMDS Medical Control Provider"
 
 participant "$str_sdc_sc" as sdc_sc
 participant "$str_sdc_sp" as sdc_sp

--- a/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
+++ b/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
@@ -358,12 +358,6 @@ SDPi-P actor roles and responsibilities are described in the subsections below.
 Unless otherwise specified below, individual transaction requirements are specified in TF-2   <<vol2_clause_transactions>>, and requirements related to content modules are detailed in TF-3 <<vol3_clause_content_modules>>.
 This section documents any additional requirements on the profile’s content actors.
 
-////
-
-#TODO:  WHY IS THE FOLLOWING SEQUENCE DIAGRAM HERE - SHOULDN'T IT BE IN Concepts?#
-
-////
-
 <<vol1_figure_sdpi_p_example_sequence_diagram>> illustrates a typical (not comprehensive) exchange scenario between SDPi-P actors:
 
 [#vol1_figure_sdpi_p_example_sequence_diagram]

--- a/asciidoc/volume1/tf1-ch-11-sdpi-r.adoc
+++ b/asciidoc/volume1/tf1-ch-11-sdpi-r.adoc
@@ -49,12 +49,6 @@ image::../images/vol1-diagram-sdpi-r-actor.svg[]
 
 {empty} +
 
-////
-
-#TODO:  In the table below, are any of these Receiver vs. Responder?  If so, then we may need to add a note like in SDPi-P
-
-////
-
 [#vol1_table_sdpi_r_actors_transactions]
 .SDPi-R Profile - Actors and Transactions
 [%autowidth]
@@ -121,6 +115,27 @@ Note 1: If the <<vol1_spec_sdpi_r_actor_somds_dec_gateway>> implements the <<vol
 
 [#vol1_clause_sdpi_r_actor_descriptions_actor_profile_requirements]
 ==== Actor Descriptions and Actor Profile Requirements
+
+SDPi-R actor roles and responsibilities are described in the subsections below.
+
+Unless otherwise specified below, individual transaction requirements are specified in TF-2   <<vol2_clause_transactions>>, and requirements related to content modules are detailed in TF-3 <<vol3_clause_content_modules>>.
+This section documents any additional requirements on the profile’s content actors.
+
+////
+TODO:
+    - Consider adding more descriptive content to this sequence diagram, especially the intersection of this profile and SDPi-P (adding transactions from the start of the conversation + SDPi-P actors;
+    - Add a gateway sequence diagram here or below in the gateway actor
+////
+
+<<vol1_figure_sdpi_r_example_sequence_diagram>> illustrates a typical (not comprehensive) exchange scenario between SDPi-R actors:
+
+[#vol1_figure_sdpi_r_example_sequence_diagram]
+.SDPi-R Example Sequence Diagram
+
+[plantuml, target=puml-sdpi-r-example-sequence-diagram, format=svg]
+....
+include::../plantuml/vol1-figure-sdpi-r-example-sequence-diagram.puml[]
+....
 
 [#vol1_clause_sdpi_r_somds_medical_data_consumer]
 ===== SOMDS Medical Data Consumer

--- a/asciidoc/volume1/tf1-ch-12-sdpi-a.adoc
+++ b/asciidoc/volume1/tf1-ch-12-sdpi-a.adoc
@@ -174,6 +174,27 @@ Note 1: If the <<vol1_spec_sdpi_a_actor_somds_acm_gateway>> supports  <<vol1_cla
 [#vol1_clause_sdpi_a_actor_descriptions_actor_profile_requirements]
 ==== Actor Descriptions and Actor Profile Requirements
 
+SDPi-A actor roles and responsibilities are described in the subsections below.
+
+Unless otherwise specified below, individual transaction requirements are specified in TF-2   <<vol2_clause_transactions>>, and requirements related to content modules are detailed in TF-3 <<vol3_clause_content_modules>>.
+This section documents any additional requirements on the profile’s content actors.
+
+////
+TODO:
+    - Consider adding more descriptive content to this sequence diagram, especially the intersection of this profile and SDPi-P (adding transactions from the start of the conversation + SDPi-P actors;
+    - Add a gateway sequence diagram here or below in the gateway actor
+////
+
+<<vol1_figure_sdpi_a_example_sequence_diagram>> illustrates a typical (not comprehensive) exchange scenario between SDPi-A actors:
+
+[#vol1_figure_sdpi_a_example_sequence_diagram]
+.SDPi-A Example Sequence Diagram
+
+[plantuml, target=puml-sdpi-a-example-sequence-diagram, format=svg]
+....
+include::../plantuml/vol1-figure-sdpi-a-example-sequence-diagram.puml[]
+....
+
 [#vol1_clause_sdpi_a_somds_medical_alert_consumer]
 ===== SOMDS Medical Alert Consumer
 [#vol1_spec_sdpi_a_actor_somds_medical_alert_consumer, reftext='SOMDS Medical Alert Consumer']
@@ -249,12 +270,32 @@ If a <<label_system_type_name_sas>> is being created, it may incorporate both <<
 [%autowidth]
 [cols="1"]
 |===
-a| *SDPi Supplement Version Note*:  This section is left intentionally blank to indicate capabilities that will be added in a future version of the SDPi Supplement.
+a| *SDPi Supplement Version Note*:  This section is intentionally left incomplete blank to indicate capabilities that will be added in a future version of the SDPi Supplement.
+As stated elsewhere, the completion of the <<ref_ieee_11073_10702_202x>> standard is required before this profile can be completed (beyond alert reporting for DIS capabilities), and that is esecially the case for alert delegation.
+
+*_The sequence diagram below for delegation is provided for informative purposes only and will be finalized when the IEEE standard and this profile option are completed._*
 
 This option will enable <<vol1_spec_sdpi_a_actor_somds_medical_alert_provider>> systems to safely and reliably transfer or "delegate" audible annunciation of alert conditions to another system.
 This option will enable both the DEV-41 <<transaction_name_manage_medical_alert_delegation>> and DEV-42 <<transaction_name_delegate_medical_alert>> transactions.
 
 |===
+
+////
+TODO:
+    - Consider adding more descriptive content to this sequence diagram, especially the intersection of this profile and SDPi-P (adding transactions from the start of the conversation + SDPi-P actors;
+    - Add a gateway sequence diagram here or below in the gateway actor
+////
+
+<<vol1_figure_sdpi_a_option_delegate_medical_alert_example_sequence_diagram>> illustrates a typical (not comprehensive) alert delegation scenario between SDPi-A actors:
+
+[#vol1_figure_sdpi_a_option_delegate_medical_alert_example_sequence_diagram]
+.SDPi-A Delegate Medical Alert Example Sequence Diagram
+
+[plantuml, target=puml-sdpi-a-delegation_example-sequence-diagram, format=svg]
+....
+include::../plantuml/vol1-figure-sdpi-a-delegation-example-sequence-diagram.puml[]
+....
+
 
 [#vol1_clause_sdpi_a_actor_option_alert_user_acknowledgement]
 ==== Alert User Acknowledgement Option

--- a/asciidoc/volume1/tf1-ch-13-sdpi-xc.adoc
+++ b/asciidoc/volume1/tf1-ch-13-sdpi-xc.adoc
@@ -75,6 +75,28 @@ image::../images/vol1-diagram-sdpi-xc-actor.svg[]
 [#vol1_clause_sdpi_xd_actor_descriptions_actor_profile_requirements]
 ==== Actor Descriptions and Actor Profile Requirements
 
+SDPi-xC actor roles and responsibilities are described in the subsections below.
+
+Unless otherwise specified below, individual transaction requirements are specified in TF-2   <<vol2_clause_transactions>>, and requirements related to content modules are detailed in TF-3 <<vol3_clause_content_modules>>.
+This section documents any additional requirements on the profile’s content actors.
+
+////
+TODO:
+    - Consider adding more descriptive content to this sequence diagram, especially the intersection of this profile and SDPi-P (adding transactions from the start of the conversation + SDPi-P actors;
+    - Add a gateway sequence diagram here or below in the gateway actor
+////
+
+<<vol1_figure_sdpi_xc_example_sequence_diagram>> illustrates a typical (not comprehensive) exchange scenario between SDPi-xC actors:
+
+[#vol1_figure_sdpi_xc_example_sequence_diagram]
+.SDPi-xC Example Sequence Diagram
+
+[plantuml, target=puml-sdpi-xc-example-sequence-diagram, format=svg]
+....
+include::../plantuml/vol1-figure-sdpi-xc-example-sequence-diagram.puml[]
+....
+
+
 [#vol1_clause_sdpi_xc_somds_medical_control_consumer]
 ===== SOMDS Medical Control Consumer
 [#vol1_spec_sdpi_xc_actor_somds_medical_control_consumer, reftext='SOMDS Medical Control Consumer']


### PR DESCRIPTION
Added illustrative PUML diagrams to the -Reporting, -Alerting & -externalControl profiles. Updated the PUML diagrams with the correct actor names.

Closes #119 

## 📑 Description
Adding additional sequence diagrams to the three profiles (-R, -A & -xC) will help readers understand the rational and use behind the additional transactions.  