### PR TITLE
Change actor references.

### DIFF
--- a/asciidoc/volume0/tf0-ch-d-glossary.adoc
+++ b/asciidoc/volume0/tf0-ch-d-glossary.adoc
@@ -56,7 +56,7 @@
 | SDC
 
 | [[term_coded_attribute, Coded Attribute]] Coded Attribute
-| A BICEPS participant model extension that allows for a <<actor_somds_provider>> to provide attributes from the first partition of the IEEE 11073-10101 nomenclature. Specified in <<vol3_clause_coded_attribute>>.
+| A BICEPS participant model extension that allows for a <<vol1_spec_sdpi_p_actor_somds_provider>> to provide attributes from the first partition of the IEEE 11073-10101 nomenclature. Specified in <<vol3_clause_coded_attribute>>.
 |
 |
 | See https://www.nist.gov/conformity-assessment[NIST CA resources page]
@@ -77,7 +77,7 @@
 | SDC
 
 | [[term_discovery_scope, Discovery Scope]] Discovery Scope
-| A set of zero to many identifiers that allows for organizing <<actor_somds_provider>>s into logical groups.
+| A set of zero to many identifiers that allows for organizing <<vol1_spec_sdpi_p_actor_somds_provider>>s into logical groups.
 |
 |
 |
@@ -161,7 +161,7 @@
 | Organization
 
 | [[term_medical_data_information_base,Medical Data Information Base (MDIB)]] Medical Data Information Base
-| Structured collection of any data objects that are provided by a <<actor_somds_provider>> or <<actor_biceps_content_creator>>, including both descriptive and state information.
+| Structured collection of any data objects that are provided by a <<vol1_spec_sdpi_p_actor_somds_provider>> or <<actor_biceps_content_creator>>, including both descriptive and state information.
 |
 | [[acronym_mdib,MDIB]] MDIB
 | <<ref_ieee_11073_10207_2017>>
@@ -269,7 +269,7 @@ elements, from requirements to system components to Verification & Validation te
 |
 
 | [[term_poc_dashboard,PoC Dashboard]] Point of Care Dashboard
-| A system that displays information from one or more <<actor_somds_participant>> systems associated with a single patient. Similar to a <<term_cockpit>> but without device-external control capabilities. May include both metric and alert information.
+| A system that displays information from one or more <<vol1_spec_sdpi_p_actor_somds_participant>> systems associated with a single patient. Similar to a <<term_cockpit>> but without device-external control capabilities. May include both metric and alert information.
 | Dashboard
 |
 |
@@ -297,7 +297,7 @@ elements, from requirements to system components to Verification & Validation te
 |
 
 | [[term_removable_subsystem,Removable Subsystem]] Removable Subsystem
-| A subsystem of a <<actor_somds_provider>> that can be attached to or removed from the <<actor_somds_provider>> and that is represented in the <<acronym_mdib>>.
+| A subsystem of a <<vol1_spec_sdpi_p_actor_somds_provider>> that can be attached to or removed from the <<vol1_spec_sdpi_p_actor_somds_provider>> and that is represented in the <<acronym_mdib>>.
 |
 |
 | See also <<ref_ieee_11073_10700_2022>>
@@ -361,7 +361,7 @@ implements a service-oriented <<acronym_sdc>> architecture composed of service p
 |
 
 | [[term_somds_provider_uid, SOMDS Provider UID]] SOMDS Provider UID
-| A globally unique identifier <<acronym_uid>> for a <<actor_somds_provider>> that is stable across re-initializations.
+| A globally unique identifier <<acronym_uid>> for a <<vol1_spec_sdpi_p_actor_somds_provider>> that is stable across re-initializations.
 | [[acronym_uid,UID]] UID
 |
 |
@@ -375,7 +375,7 @@ implements a service-oriented <<acronym_sdc>> architecture composed of service p
 | Organization
 
 | [[term_system_function_contribution,System Function Contribution (SFC)]] System Function Contribution
-| Function of a <<actor_somds_participant>> that contributes to a <<term_clinical_function>> provided by a <<term_service_oriented_medical_device_system>>.
+| Function of a <<vol1_spec_sdpi_p_actor_somds_participant>> that contributes to a <<term_clinical_function>> provided by a <<term_service_oriented_medical_device_system>>.
 |
 | [[acronym_sfc,SFC]] SFC
 | Adapted from <<ref_ieee_11073_10700_2022>>.
@@ -389,7 +389,7 @@ implements a service-oriented <<acronym_sdc>> architecture composed of service p
 |
 
 | [[term_transport_address, Transport Address]] Transport Address
-| A physical endpoint address that can be used to communicate with a <<actor_somds_provider>>.
+| A physical endpoint address that can be used to communicate with a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 | XAddr
 |
 |

--- a/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
+++ b/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
@@ -681,7 +681,7 @@ The <<acronym_sdc>> <<acronym_biceps>> standard, which SDPi-P profiles, consists
 [#figure_sdc_biceps_components_model]
 image::../images/vol1-diagram-sdc-biceps-component-view.svg[align=center]
 
-The <<term_medical_data_information_base>> component applies to all participating systems and consists of a *_descriptive model_* (e.g., what services and information a <<actor_somds_provider>> supports), and a state model.
+The <<term_medical_data_information_base>> component applies to all participating systems and consists of a *_descriptive model_* (e.g., what services and information a <<vol1_spec_sdpi_p_actor_somds_provider>> supports), and a state model.
 The discovery and communications models combine to enable device-to-device messaging and to identify both systems and services available on the network.
 The descriptive model is covered in more detail in <<vol3_clause_sdc_biceps_semantic_content_module>>, but the following <<figure_sdc_biceps_mdib_descriptors_states>> shows how network efficiency is achieved by searating descriptive information from dynamic state information:
 
@@ -689,9 +689,9 @@ The descriptive model is covered in more detail in <<vol3_clause_sdc_biceps_sema
 [#figure_sdc_biceps_mdib_descriptors_states]
 image::../images/vol1-diagram-sdc-biceps-mdib-description-state.svg[align=center]
 
-For every <<actor_somds_provider>> system, there is a descriptive model that includes a detailed specification of every element in the <<acronym_mdib>>.
+For every <<vol1_spec_sdpi_p_actor_somds_provider>> system, there is a descriptive model that includes a detailed specification of every element in the <<acronym_mdib>>.
 For each Descriptor, though, there is a State element (note the inclusion of a State::DescriptorHandle), that can be used to determine the value and change status for the associated descriptor.
-Therefore, though the <<acronym_mdib>> of a <<actor_somds_provider>> system must be retrieved at discovery and connection time, subsequent updates can be made upon state changes, greatly reducing network communication overhead.
+Therefore, though the <<acronym_mdib>> of a <<vol1_spec_sdpi_p_actor_somds_provider>> system must be retrieved at discovery and connection time, subsequent updates can be made upon state changes, greatly reducing network communication overhead.
 
 For an example of how <<acronym_biceps>> components (see <<figure_sdc_biceps_components_model>>) and <<acronym_mdib>> descriptors and states (see <<figure_sdc_biceps_mdib_descriptors_states>>) support <<term_plug_and_trust>> interoperability, a typical conversation is provided in <<vol1_figure_sdpi_p_example_sequence_diagram>>.
 
@@ -915,7 +915,7 @@ No additional safety requirements or considerations are identified for this tech
 ==== Effectiveness Requirements & Considerations
 No additional effectiveness requirements or considerations are identified for this technical framework element beyond those specified in the _<<acronym_ses>> General Considerations_ section above.
 ==== Security Requirements & Considerations
-Security is foundational for all interactions between <<actor_somds_participant>> Actors, with a clear distinction being made between information that may be exchanged outside of a secure connection (e.g., during network discovery transactions).
+Security is foundational for all interactions between <<vol1_spec_sdpi_p_actor_somds_participant>> Actors, with a clear distinction being made between information that may be exchanged outside of a secure connection (e.g., during network discovery transactions).
 Specific security technologies may vary based on the implementation technology being used, and will be detailed in the appropriate TF-2 technology specifications.
 All transactions indicate whether they require secure or unsecured connections.
 

--- a/asciidoc/volume2/connect-time-algorithm/tf2-ch-a-mdpws-connect-time-algorithm.adoc
+++ b/asciidoc/volume2/connect-time-algorithm/tf2-ch-a-mdpws-connect-time-algorithm.adoc
@@ -1,13 +1,13 @@
 ==== Connection Time Delay
 
-When a <<actor_somds_provider>> joins a network and sends out a <<vol2_clause_dev_23_message_hello, {var_label_dev_23_message_hello}>> message, depending on the number of <<actor_somds_consumer>>s that are interested in the data of that <<actor_somds_provider>>, the <<actor_somds_provider>> can get overwhelmed by incoming TCP connection requests and TLS handshakes. <<actor_somds_provider>>s and <<actor_somds_consumer>>s can implement different actions in order to avoid flooding of TCP connection requests and TLS handshakes under normal operating conditions. Each action comes with individual advantages and disadvantages.
+When a <<vol1_spec_sdpi_p_actor_somds_provider>> joins a network and sends out a <<vol2_clause_dev_23_message_hello, {var_label_dev_23_message_hello}>> message, depending on the number of <<vol1_spec_sdpi_p_actor_somds_consumer>>s that are interested in the data of that <<vol1_spec_sdpi_p_actor_somds_provider>>, the <<vol1_spec_sdpi_p_actor_somds_provider>> can get overwhelmed by incoming TCP connection requests and TLS handshakes. <<vol1_spec_sdpi_p_actor_somds_provider>>s and <<vol1_spec_sdpi_p_actor_somds_consumer>>s can implement different actions in order to avoid flooding of TCP connection requests and TLS handshakes under normal operating conditions. Each action comes with individual advantages and disadvantages.
 
 ===== Provider-controlled Delay
 
-<<ref_ieee_11073_20701_2018>> normatively references <<ref_oasis_dpws_2009>> which in turn leverages <<ref_oasis_ws_discovery_2009>> to provide distributed (ad-hoc) or centralized (managed) service registries. WS-Discovery decomposes into two message sequences, <<vol2_clause_appendix_mdpws_dev_23, implicit discovery>> and <<vol2_clause_appendix_mdpws_dev_24, explicit discovery>> of which implicit discovery can lead to loss of performance for <<actor_somds_provider>>s when multiple <<actor_somds_consumer>>s attempt to connect at the same time.
+<<ref_ieee_11073_20701_2018>> normatively references <<ref_oasis_dpws_2009>> which in turn leverages <<ref_oasis_ws_discovery_2009>> to provide distributed (ad-hoc) or centralized (managed) service registries. WS-Discovery decomposes into two message sequences, <<vol2_clause_appendix_mdpws_dev_23, implicit discovery>> and <<vol2_clause_appendix_mdpws_dev_24, explicit discovery>> of which implicit discovery can lead to loss of performance for <<vol1_spec_sdpi_p_actor_somds_provider>>s when multiple <<vol1_spec_sdpi_p_actor_somds_consumer>>s attempt to connect at the same time.
 
 
-In order to suppress concurrent connection attempts, in the ad-hoc mode a <<actor_somds_provider>> can omit the <<term_transport_address>> from the {var_label_dev_23_message_hello} message. Subsequently, a <<actor_somds_consumer>> needs to send a {var_label_dev_24_message_resolve} message to resolve the <<actor_somds_provider>>'s <<term_transport_address>>.
+In order to suppress concurrent connection attempts, in the ad-hoc mode a <<vol1_spec_sdpi_p_actor_somds_provider>> can omit the <<term_transport_address>> from the {var_label_dev_23_message_hello} message. Subsequently, a <<vol1_spec_sdpi_p_actor_somds_consumer>> needs to send a {var_label_dev_24_message_resolve} message to resolve the <<vol1_spec_sdpi_p_actor_somds_provider>>'s <<term_transport_address>>.
 
 [none]
 * icon:plus[] Deferral is controlled by the entity that is affected by concurrent connection attempts.
@@ -16,22 +16,22 @@ In order to suppress concurrent connection attempts, in the ad-hoc mode a <<acto
 .R0001
 [sdpi_requirement#r0001,sdpi_req_level=may]
 ****
-A <<actor_somds_provider>> may delay sending a Resolve Match response to a Resolve message.
+A <<vol1_spec_sdpi_p_actor_somds_provider>> may delay sending a Resolve Match response to a Resolve message.
 
 .Notes
 [%collapsible]
 ====
-NOTE: It is up to the <<term_manufacturer>> of the <<actor_somds_provider>> to choose a delay that fits the hardware capabilities of the <<actor_somds_provider>> for concurrent connection requests.
+NOTE: It is up to the <<term_manufacturer>> of the <<vol1_spec_sdpi_p_actor_somds_provider>> to choose a delay that fits the hardware capabilities of the <<vol1_spec_sdpi_p_actor_somds_provider>> for concurrent connection requests.
 ====
 ****
 
 ===== Consumer-controlled Delay
 
 <<ref_ieee_11073_20701_2018>> introduces the concept of priority groups.
-According to <<ref_ieee_11073_20701_2018, glue:R0076>>, a <<actor_somds_consumer>> is required to have a priority group assigned, which causes the <<actor_somds_consumer>> to postpone initial connection requests by a certain time once it retrieved the <<term_transport_address>> of a <<actor_somds_provider>>.
+According to <<ref_ieee_11073_20701_2018, glue:R0076>>, a <<vol1_spec_sdpi_p_actor_somds_consumer>> is required to have a priority group assigned, which causes the <<vol1_spec_sdpi_p_actor_somds_consumer>> to postpone initial connection requests by a certain time once it retrieved the <<term_transport_address>> of a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 Depending on the priority groups 0 to 9, with increasing group numbers the initial connection delay increases linearly based on random or fixed durations in predefined intervals.
 
-<<ref_ieee_11073_20701_2018>> does not define numbers for specific purposes but rather appeal to <<term_manufacturer>>s to implement priority groups meaningful to their <<actor_somds_consumer>>'s purpose.
+<<ref_ieee_11073_20701_2018>> does not define numbers for specific purposes but rather appeal to <<term_manufacturer>>s to implement priority groups meaningful to their <<vol1_spec_sdpi_p_actor_somds_consumer>>'s purpose.
 
 [none]
 * icon:plus[] The deferral works in ad-hoc and managed mode discovery.
@@ -40,12 +40,12 @@ Depending on the priority groups 0 to 9, with increasing group numbers the initi
 .R0002
 [sdpi_requirement#r0002,sdpi_req_level=should]
 ****
-A <<actor_somds_consumer>> should be configurable with a priority group number in accordance with <<ref_ieee_11073_20701_2018>> R0076.
+A <<vol1_spec_sdpi_p_actor_somds_consumer>> should be configurable with a priority group number in accordance with <<ref_ieee_11073_20701_2018>> R0076.
 
 .Notes
 [%collapsible]
 ====
-NOTE: As it is not trivial to determine the priority of a <<actor_somds_consumer>> in all and every circumstance, the <<term_manufacturer>> can provide configurable options that allow for flexible adaptation on environmental changes.
+NOTE: As it is not trivial to determine the priority of a <<vol1_spec_sdpi_p_actor_somds_consumer>> in all and every circumstance, the <<term_manufacturer>> can provide configurable options that allow for flexible adaptation on environmental changes.
 ====
 ****
 
@@ -54,7 +54,7 @@ NOTE: As it is not trivial to determine the priority of a <<actor_somds_consumer
 .R0003
 [sdpi_requirement#r0003,sdpi_req_level=shall]
 ****
-If a <<term_manufacturer>> does not intend to enforce configuration of priority groups during installation of its <<actor_somds_consumer>>, the manufacturer shall pre-configure priority groups to a reasonable default value that reflects the highest criticality of the <<actor_somds_consumer>>'s system function.
+If a <<term_manufacturer>> does not intend to enforce configuration of priority groups during installation of its <<vol1_spec_sdpi_p_actor_somds_consumer>>, the manufacturer shall pre-configure priority groups to a reasonable default value that reflects the highest criticality of the <<vol1_spec_sdpi_p_actor_somds_consumer>>'s system function.
 
 .Notes
 [%collapsible]
@@ -70,12 +70,12 @@ NOTE: Guidelines for reasonable default values are shown in <<vol2_clause_append
 .R0004
 [sdpi_requirement#r0004,sdpi_req_level=may]
 ****
-If a <<term_manufacturer>> does not intend to allow for a user to configure a priority group after the installation process of its <<actor_somds_consumer>> is finished, the manufacturer may dynamically determine a reasonable priority group for its <<actor_somds_consumer>> according to the highest criticality of the <<actor_somds_consumer>>'s system function on startup.
+If a <<term_manufacturer>> does not intend to allow for a user to configure a priority group after the installation process of its <<vol1_spec_sdpi_p_actor_somds_consumer>> is finished, the manufacturer may dynamically determine a reasonable priority group for its <<vol1_spec_sdpi_p_actor_somds_consumer>> according to the highest criticality of the <<vol1_spec_sdpi_p_actor_somds_consumer>>'s system function on startup.
 
 .Notes
 [%collapsible]
 ====
-NOTE: In order to dynamically determine the priority group within a certain range, a <<actor_somds_consumer>> can use, for example, a random number generator function or a real-time clock.
+NOTE: In order to dynamically determine the priority group within a certain range, a <<vol1_spec_sdpi_p_actor_somds_consumer>> can use, for example, a random number generator function or a real-time clock.
 
 NOTE: Guidelines for reasonable priority group ranges are shown in <<vol2_clause_appendix_a_mdpws_connect_time_algorithm_priority_groups>>.
 ====
@@ -83,7 +83,7 @@ NOTE: Guidelines for reasonable priority group ranges are shown in <<vol2_clause
 
 ====== Priority Group Guidelines
 
-<<vol2_clause_appendix_a_mdpws_connect_time_algorithm_priority_groups>> exhibits guidelines to <<term_manufacturer>>s or responsible organizations as to which priority group can be used for a certain <<actor_somds_consumer>> system function criticality.
+<<vol2_clause_appendix_a_mdpws_connect_time_algorithm_priority_groups>> exhibits guidelines to <<term_manufacturer>>s or responsible organizations as to which priority group can be used for a certain <<vol1_spec_sdpi_p_actor_somds_consumer>> system function criticality.
 
 .Exemplary priority group assignments
 [#vol2_clause_appendix_a_mdpws_connect_time_algorithm_priority_groups,cols="1,1,2,4"]

--- a/asciidoc/volume2/dev-23/tf2-ch-a-mdpws-dev-23.adoc
+++ b/asciidoc/volume2/dev-23/tf2-ch-a-mdpws-dev-23.adoc
@@ -28,7 +28,7 @@ include::../../listings/vol2-clause-appendix-a-mdpws-dev-23-hello.xml[]
 ====== Message Semantics
 
 `s12:Envelope/s12:Body/wsd:Hello/wsa:EndpointReference/wsa:Address`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s <<payload_dev_23_provider_uid>> as URI.
-`s12:Envelope/s12:Body/wsd:Hello/wsd:Scopes`:: The <<actor_somds_provider>>'s <<payload_dev_23_discovery_scope>> as a list of URIs.
+`s12:Envelope/s12:Body/wsd:Hello/wsd:Scopes`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s <<payload_dev_23_discovery_scope>> as a list of URIs.
 
 [#vol2_clause_appendix_mdpws_dev_23_hello_message_trigger_events]
 ====== Trigger Events
@@ -37,19 +37,19 @@ The abstracted trigger events as listed in <<vol2_clause_dev_23_message_announce
 
 This message is sent
 
-1. when a <<actor_somds_provider>> is assigned an IP address after having joined the network,
-2. when a <<actor_somds_provider>> is reassigned an IP address, or
-3. when a <<actor_somds_provider>> changes its <<payload_dev_23_discovery_scope>>.
+1. when a <<vol1_spec_sdpi_p_actor_somds_provider>> is assigned an IP address after having joined the network,
+2. when a <<vol1_spec_sdpi_p_actor_somds_provider>> is reassigned an IP address, or
+3. when a <<vol1_spec_sdpi_p_actor_somds_provider>> changes its <<payload_dev_23_discovery_scope>>.
 
 IP address reassignment can occur because of intended or unintended interruptions in the network connection, network reconfiguration during operation (e.g. by plugging of Ethernet switches), or other causes.
 
-It is assumed that <<actor_somds_participant>> are connected to an IP network that uses dynamic IP address assignment managed by a DHCP server.
+It is assumed that <<vol1_spec_sdpi_p_actor_somds_participant>> are connected to an IP network that uses dynamic IP address assignment managed by a DHCP server.
 The use of static IP addresses is discouraged as it may lead to IP address conflicts, and hence severe communication disruption, in case of network reconfiguration during operation (e.g. by plugging of Ethernet switches).
 
 .R2000
 [sdpi_requirement#r2000,sdpi_req_level=should]
 ****
-A <<actor_somds_participant>> should use a dynamically configured IP address.
+A <<vol1_spec_sdpi_p_actor_somds_participant>> should use a dynamically configured IP address.
 ****
 
 :var_expected_actions_ref: <<vol2_clause_dev_23_message_hello>>
@@ -64,26 +64,26 @@ In addition to the Hello message trigger events defined in <<vol2_clause_appendi
 .R2001
 [sdpi_requirement#r2001,sdpi_req_level=shall]
 ****
-A <<actor_somds_provider>> shall periodically send Hello messages at random intervals between 60 seconds and 120 seconds.
+A <<vol1_spec_sdpi_p_actor_somds_provider>> shall periodically send Hello messages at random intervals between 60 seconds and 120 seconds.
 
 .Notes
 [%collapsible]
 ====
-The random interval between 60 seconds and 120 seconds aims to prevent <<actor_somds_provider>>s from congesting the network by sending recurring Hello messages at the same time.
+The random interval between 60 seconds and 120 seconds aims to prevent <<vol1_spec_sdpi_p_actor_somds_provider>>s from congesting the network by sending recurring Hello messages at the same time.
 ====
 ****
 
 [#vol2_clause_appendix_mdpws_dev_23_hello_message_size,sdpi_level=+1]
 ====== Hello Message Size
-In IT networks such as WLAN, messages can get lost or fragmented and data can consequently be delivered in the wrong order, especially with increasing concurrent data traffic caused by an increasing number of <<actor_somds_participant>>s.
+In IT networks such as WLAN, messages can get lost or fragmented and data can consequently be delivered in the wrong order, especially with increasing concurrent data traffic caused by an increasing number of <<vol1_spec_sdpi_p_actor_somds_participant>>s.
 This becomes crucial when connectionless transport protocols like UDP are used.
 <<ref_ieee_11073_20701_2018>> leverages UDP for service discovery and hence suffers from the aforementioned issue.
-To mitigate this, <<actor_somds_provider>>s are advised to create Hello messages of less than the MTU size over UDP, in accordance requirement R0029 in <<ref_oasis_dpws_2009>>.
+To mitigate this, <<vol1_spec_sdpi_p_actor_somds_provider>>s are advised to create Hello messages of less than the MTU size over UDP, in accordance requirement R0029 in <<ref_oasis_dpws_2009>>.
 
 Moreover, as further mitigation measure, note that <<ref_oasis_soap_over_udp_v1_1>> already defines a non-normative retry and back-off algorithm.
 
 .R2002
 [sdpi_requirement#r2002,sdpi_req_level=should]
 ****
-A <<actor_somds_participant>> should implement the retry and back-off algorithm defined in SOAP-over-UDP, Appendix A.
+A <<vol1_spec_sdpi_p_actor_somds_participant>> should implement the retry and back-off algorithm defined in SOAP-over-UDP, Appendix A.
 ****

--- a/asciidoc/volume2/dev-23/tf2-dev-23-summary.adoc
+++ b/asciidoc/volume2/dev-23/tf2-dev-23-summary.adoc
@@ -1,4 +1,4 @@
 // DEV-23 Transaction Summary
 
-Notify all <<vol1_spec_sdpi_p_actor_somds_consumer>>s that a <<vol1_spec_sdpi_p_actor_somds_provider>> is connected to the network and ready to exchange messages with other <<actor_somds_participant>>s.
+Notify all <<vol1_spec_sdpi_p_actor_somds_consumer>>s that a <<vol1_spec_sdpi_p_actor_somds_provider>> is connected to the network and ready to exchange messages with other <<vol1_spec_sdpi_p_actor_somds_participant>>s.
 

--- a/asciidoc/volume2/dev-23/tf2-dev-23.adoc
+++ b/asciidoc/volume2/dev-23/tf2-dev-23.adoc
@@ -24,8 +24,8 @@ include::tf2-dev-23-summary.adoc[]
 |<<vol1_spec_sdpi_p_actor_somds_provider>>
 |Announces its presence by multicasting <<vol2_clause_dev_23_message_hello, {var_label_dev_23_message_hello}>> messages to all listening systems.
 
-|<<actor_somds_consumer>>
-|Listens for <<vol2_clause_dev_23_message_hello, {var_label_dev_23_message_hello}>> messages to identify any <<actor_somds_provider>>s that it may exchange messages with and further retrieve a <<actor_somds_provider>>'s service capabilities.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+|Listens for <<vol2_clause_dev_23_message_hello, {var_label_dev_23_message_hello}>> messages to identify any <<vol1_spec_sdpi_p_actor_somds_provider>>s that it may exchange messages with and further retrieve a <<vol1_spec_sdpi_p_actor_somds_provider>>'s service capabilities.
 
 |===
 
@@ -44,33 +44,33 @@ include::../../plantuml/vol2-figure-dev-23-sequence.puml[]
 [#vol2_clause_dev_23_message_hello]
 ===== {var_label_dev_23_message_hello} Message
 
-<<acronym_biceps>> specifies an implicit discovery protocol for allowing <<actor_somds_consumer>>s to receive a notification when a <<actor_somds_provider>> is ready to exchange messages with other <<actor_somds_consumer>>s.
+<<acronym_biceps>> specifies an implicit discovery protocol for allowing <<vol1_spec_sdpi_p_actor_somds_consumer>>s to receive a notification when a <<vol1_spec_sdpi_p_actor_somds_provider>> is ready to exchange messages with other <<vol1_spec_sdpi_p_actor_somds_consumer>>s.
 The corresponding message for this transaction is called _{var_label_dev_23_message_hello}_.
 
 Note that the {var_label_dev_23_message_hello} message described in this clause is a generic/abstract concept that can be implemented differently.
 It should not be confused with actual transport message specifications like, e.g. the WS-Discovery Hello message as described in <<vol2_clause_appendix_mdpws_dev_23>>.
 
-The {var_label_dev_23_message_hello} is a multicast message that is sent from each <<actor_somds_provider>> to all listening <<actor_somds_consumer>>s (zero to many). Limited but sufficient information is provided with the message to enable <<actor_somds_consumer>>s to determine if they are interested in connecting with the <<actor_somds_provider>> discovering additional information.
+The {var_label_dev_23_message_hello} is a multicast message that is sent from each <<vol1_spec_sdpi_p_actor_somds_provider>> to all listening <<vol1_spec_sdpi_p_actor_somds_consumer>>s (zero to many). Limited but sufficient information is provided with the message to enable <<vol1_spec_sdpi_p_actor_somds_consumer>>s to determine if they are interested in connecting with the <<vol1_spec_sdpi_p_actor_somds_provider>> discovering additional information.
 
 [#vol2_clause_dev_23_message_announce_network_presence_trigger_events]
 ====== Trigger Events
 
 This message is sent
 
-1. whenever a <<actor_somds_provider>> joins an <<acronym_md_lan>>,
-2. when a <<actor_somds_provider>> returns to normal _on-line_ operation after having indicated temporary suspension of message exchanges, or
-3. when a <<actor_somds_provider>> changes its <<payload_dev_23_discovery_scope>>.
+1. whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> joins an <<acronym_md_lan>>,
+2. when a <<vol1_spec_sdpi_p_actor_somds_provider>> returns to normal _on-line_ operation after having indicated temporary suspension of message exchanges, or
+3. when a <<vol1_spec_sdpi_p_actor_somds_provider>> changes its <<payload_dev_23_discovery_scope>>.
 
 [#vol2_clause_dev_23_message_announce_network_presence_message_semantics]
 ====== Message Semantics
 
 [[payload_dev_23_provider_uid]]Provider UID:: The <<term_somds_provider_uid>>.
-[[payload_dev_23_discovery_scope]]Discovery Scope:: The <<term_discovery_scope>> of the <<actor_somds_provider>>.
+[[payload_dev_23_discovery_scope]]Discovery Scope:: The <<term_discovery_scope>> of the <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 [#vol2_clause_dev_23_message_announce_network_presence_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_provider>> sends this message, there is no expected or required responses. This is due to the fact that either there are no <<actor_somds_consumer>>s listening for announcement messages, or the information in the message (e.g., Discovery Type) is not of interest to any receiving <<actor_somds_consumer>>s.
+When a <<vol1_spec_sdpi_p_actor_somds_provider>> sends this message, there is no expected or required responses. This is due to the fact that either there are no <<vol1_spec_sdpi_p_actor_somds_consumer>>s listening for announcement messages, or the information in the message (e.g., Discovery Type) is not of interest to any receiving <<vol1_spec_sdpi_p_actor_somds_consumer>>s.
 
 [#vol2_clause_dev_23_message_announce_network_presence_ses]
 include::../dev-x-default-ses-unsecured-mode.adoc[]

--- a/asciidoc/volume2/dev-25/tf2-ch-a-mdpws-dev-25.adoc
+++ b/asciidoc/volume2/dev-25/tf2-ch-a-mdpws-dev-25.adoc
@@ -54,9 +54,9 @@ include::../dev-a-default-trigger-events.adoc[]
 
 ====== Message Semantics
 
-`s12:Envelope/s12:Body/wsm:Metadata/wsm:MetadataSection/dpws:ThisModel`:: The <<actor_somds_provider>>'s metadata that maps to the <<message_semantics_discover_biceps_services_model, Model Metadata>>.
+`s12:Envelope/s12:Body/wsm:Metadata/wsm:MetadataSection/dpws:ThisModel`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s metadata that maps to the <<message_semantics_discover_biceps_services_model, Model Metadata>>.
 
-`s12:Envelope/s12:Body/wsm:Metadata/wsm:MetadataSection/dpws:ThisDevice`:: The <<actor_somds_provider>>'s metadata that maps to the <<message_semantics_discover_biceps_services_device, Device Metadata>>.
+`s12:Envelope/s12:Body/wsm:Metadata/wsm:MetadataSection/dpws:ThisDevice`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s metadata that maps to the <<message_semantics_discover_biceps_services_device, Device Metadata>>.
 
 `s12:Envelope/s12:Body/wsm:Metadata/wsm:MetadataSection/dpws:Relationship/dpws:Hosted/dpws:Types`:: Designates available <<payload_dev_25_get_metadata_biceps_services>> by providing a list of service types that contains at least one or more of the BICEPS services as mapped in <<vol2_table_appendix_mdpws_dev_25_hosted_types>>.
 

--- a/asciidoc/volume2/dev-25/tf2-dev-25-summary.adoc
+++ b/asciidoc/volume2/dev-25/tf2-dev-25-summary.adoc
@@ -1,4 +1,4 @@
 // DEV-25 Transaction Summary
 
-Exchange resources metadata between a <<actor_somds_provider>> and a <<actor_somds_consumer>>.
+Exchange resources metadata between a <<vol1_spec_sdpi_p_actor_somds_provider>> and a <<vol1_spec_sdpi_p_actor_somds_consumer>>.
 

--- a/asciidoc/volume2/dev-25/tf2-dev-25.adoc
+++ b/asciidoc/volume2/dev-25/tf2-dev-25.adoc
@@ -14,11 +14,11 @@ include::tf2-dev-25-summary.adoc[]
 |===
 |Actor |Roles
 
-|<<actor_somds_consumer>>
-| Asks for the resource representation of the <<actor_somds_provider>> via the <<vol2_clause_dev_25_message_get_metadata, GetMetadata>> message.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+| Asks for the resource representation of the <<vol1_spec_sdpi_p_actor_somds_provider>> via the <<vol2_clause_dev_25_message_get_metadata, GetMetadata>> message.
 
-|<<actor_somds_provider>>
-| Sends its resource representation to the <<actor_somds_consumer>> via the <<vol2_clause_dev_25_message_get_metadata_response, GetMetadataResponse>> message.
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
+| Sends its resource representation to the <<vol1_spec_sdpi_p_actor_somds_consumer>> via the <<vol2_clause_dev_25_message_get_metadata_response, GetMetadataResponse>> message.
 
 |===
 
@@ -37,23 +37,23 @@ include::../../plantuml/vol2-figure-dev-25-sequence.puml[]
 
 [#vol2_clause_dev_25_message_get_metadata]
 ===== GetMetadata Message
-The GetMetadata message is used by a <<actor_somds_consumer>> to request the resource representation data of a <<actor_somds_provider>>.
+The GetMetadata message is used by a <<vol1_spec_sdpi_p_actor_somds_consumer>> to request the resource representation data of a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 ====== Trigger Events
-This message is sent when a <<actor_somds_consumer>> has discovered a <<term_transport_address>> for a <<actor_somds_provider>>.
+This message is sent when a <<vol1_spec_sdpi_p_actor_somds_consumer>> has discovered a <<term_transport_address>> for a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 ====== Expected Actions
-When a <<actor_somds_consumer>> sends this message, the <<vol2_clause_dev_25_message_get_metadata_response, GetMetadataResponse>> message is expected as a response.
+When a <<vol1_spec_sdpi_p_actor_somds_consumer>> sends this message, the <<vol2_clause_dev_25_message_get_metadata_response, GetMetadataResponse>> message is expected as a response.
 
 [#vol2_clause_dev_25_message_get_metadata_response]
 ===== GetMetadataResponse Message
 The GetMetadataResponse message is sent in response to an incoming <<vol2_clause_dev_25_message_get_metadata, GetMetadata>> message.
 
 ====== Trigger Events
-The GetMetadataResponse message is sent whenever a <<actor_somds_provider>> receives a <<vol2_clause_dev_25_message_get_metadata, GetMetadata>> message.
+The GetMetadataResponse message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> receives a <<vol2_clause_dev_25_message_get_metadata, GetMetadata>> message.
 
 ====== Message Semantics
-[[payload_dev_25_get_metadata_biceps_services]]BICEPS Services:: Collection of BICEPS services the <<actor_somds_provider>> offers, including but not limited to one or multiple of the following BICEPS services (<<ref_ieee_11073_10207_2017>> Section 7.3 Service Model):
+[[payload_dev_25_get_metadata_biceps_services]]BICEPS Services:: Collection of BICEPS services the <<vol1_spec_sdpi_p_actor_somds_provider>> offers, including but not limited to one or multiple of the following BICEPS services (<<ref_ieee_11073_10207_2017>> Section 7.3 Service Model):
 * GET SERVICE (mandatory)
 * SET SERVICE
 * DESCRIPTION EVENT SERVICE
@@ -64,18 +64,18 @@ The GetMetadataResponse message is sent whenever a <<actor_somds_provider>> rece
 NOTE: There is currently no mandatory support for provision of the LOCALIZATION SERVICE, CONTAINMENT TREE SERVICE and ARCHIVE SERVICE.
 
 [#message_semantics_discover_biceps_services_device]
-Device Metadata:: Expresses <<actor_somds_provider>> characteristics that typically vary from one <<actor_somds_provider>> to another of the same kind, e.g.:
+Device Metadata:: Expresses <<vol1_spec_sdpi_p_actor_somds_provider>> characteristics that typically vary from one <<vol1_spec_sdpi_p_actor_somds_provider>> to another of the same kind, e.g.:
 * Friendly name
 * Firmware version
 * Serial number
 [#message_semantics_discover_biceps_services_model]
-Model Metadata:: Expresses <<actor_somds_provider>> characteristics that are typically fixed across all <<actor_somds_provider>>s of the same model by their <<term_manufacturer>>, e.g.:
+Model Metadata:: Expresses <<vol1_spec_sdpi_p_actor_somds_provider>> characteristics that are typically fixed across all <<vol1_spec_sdpi_p_actor_somds_provider>>s of the same model by their <<term_manufacturer>>, e.g.:
 * <<term_manufacturer>>
 * Model name
 * Model number
 
 ====== Expected Actions
-When a <<actor_somds_provider>> sends this message, there is no expected or required response.
+When a <<vol1_spec_sdpi_p_actor_somds_provider>> sends this message, there is no expected or required response.
 
 [#vol2_clause_dev_23_message_announce_network_presence_ses]
 include::../dev-x-default-ses-secured-mode.adoc[]

--- a/asciidoc/volume2/dev-27/tf2-ch-a-mdpws-dev-27.adoc
+++ b/asciidoc/volume2/dev-27/tf2-ch-a-mdpws-dev-27.adoc
@@ -86,12 +86,12 @@ include::../dev-a-default-trigger-events.adoc[]
 .R7001
 [sdpi_requirement#r7001,sdpi_req_level=shall]
 ****
-When a <<actor_somds_consumer>> requests `{var_filter_dialect_action}` filter processing in a Subscribe message, the <<actor_somds_consumer>> shall assume the receiving <<actor_somds_provider>> to perform the `{var_uri_strcmp0}` matching rule.
+When a <<vol1_spec_sdpi_p_actor_somds_consumer>> requests `{var_filter_dialect_action}` filter processing in a Subscribe message, the <<vol1_spec_sdpi_p_actor_somds_consumer>> shall assume the receiving <<vol1_spec_sdpi_p_actor_somds_provider>> to perform the `{var_uri_strcmp0}` matching rule.
 
 .Notes
 [%collapsible]
 ====
-NOTE: The `{var_uri_rfc3986}` matching rule definition implemented by <<actor_somds_provider>>s ambiguously includes the term `prefix`.
+NOTE: The `{var_uri_rfc3986}` matching rule definition implemented by <<vol1_spec_sdpi_p_actor_somds_provider>>s ambiguously includes the term `prefix`.
 As `{var_uri_rfc3986}` subsumes `{var_uri_strcmp0}`, a fallback to case-sensitive string comparison is explicit and failsafe.
 ====
 ****
@@ -138,7 +138,7 @@ include::../dev-a-default-expected-actions.adoc[]
 .R7003
 [sdpi_requirement#r7003,sdpi_req_level=shall]
 ****
-A <<actor_somds_participant>> shall leverage HTTP path dispatching to identify subscription managers and notification/end-to sinks.
+A <<vol1_spec_sdpi_p_actor_somds_participant>> shall leverage HTTP path dispatching to identify subscription managers and notification/end-to sinks.
 
 
 .Notes
@@ -155,7 +155,7 @@ NOTE: WS-Eventing allows for an event source or sink to make use of WS-Addressin
 [sdpi_requirement#r7004,sdpi_req_level=shall]
 ****
 
-In a SubscribeResponse message, a <<actor_somds_provider>> shall provide an _Expires_ element.
+In a SubscribeResponse message, a <<vol1_spec_sdpi_p_actor_somds_provider>> shall provide an _Expires_ element.
 
 .Notes
 [%collapsible]
@@ -247,7 +247,7 @@ include::../dev-a-default-expected-actions.adoc[]
 [sdpi_requirement#r7005,sdpi_req_level=shall]
 ****
 
-In a RenewResponse message, a <<actor_somds_provider>> shall provide an _Expires_ element.
+In a RenewResponse message, a <<vol1_spec_sdpi_p_actor_somds_provider>> shall provide an _Expires_ element.
 
 .Notes
 [%collapsible]

--- a/asciidoc/volume2/dev-27/tf2-dev-27-summary.adoc
+++ b/asciidoc/volume2/dev-27/tf2-dev-27-summary.adoc
@@ -1,4 +1,4 @@
 // DEV-27 Transaction Summary
 
-Establish a publish-subscribe session between a <<actor_somds_provider>>, acting as the event source, and a <<actor_somds_consumer>>, acting as the event sink.
+Establish a publish-subscribe session between a <<vol1_spec_sdpi_p_actor_somds_provider>>, acting as the event source, and a <<vol1_spec_sdpi_p_actor_somds_consumer>>, acting as the event sink.
 

--- a/asciidoc/volume2/dev-27/tf2-dev-27.adoc
+++ b/asciidoc/volume2/dev-27/tf2-dev-27.adoc
@@ -25,17 +25,17 @@ include::tf2-dev-27-summary.adoc[]
 |===
 |Actor |Roles
 
-|<<actor_somds_consumer>>
-|Initiates communication by first subscribing to a <<actor_somds_provider>> by sending a <<vol2_clause_dev_27_message_subscribe, {var_label_dev_27_message_subscribe}>> message. While the subscription is running, the subscription is kept alive by sending <<vol2_clause_dev_27_message_renew, {var_label_dev_27_message_renew}>> messages and receiving <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+|Initiates communication by first subscribing to a <<vol1_spec_sdpi_p_actor_somds_provider>> by sending a <<vol2_clause_dev_27_message_subscribe, {var_label_dev_27_message_subscribe}>> message. While the subscription is running, the subscription is kept alive by sending <<vol2_clause_dev_27_message_renew, {var_label_dev_27_message_renew}>> messages and receiving <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
 
-Finally, the <<actor_somds_consumer>> unsubscribes from a <<actor_somds_provider>> by sending an <<vol2_clause_dev_27_message_unsubscribe, {var_label_dev_27_message_unsubscribe}>> message.
+Finally, the <<vol1_spec_sdpi_p_actor_somds_consumer>> unsubscribes from a <<vol1_spec_sdpi_p_actor_somds_provider>> by sending an <<vol2_clause_dev_27_message_unsubscribe, {var_label_dev_27_message_unsubscribe}>> message.
 
-|<<actor_somds_provider>>
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
 |Listens for <<vol2_clause_dev_27_message_subscribe, {var_label_dev_27_message_subscribe}>>, <<vol2_clause_dev_27_message_renew, {var_label_dev_27_message_renew}>> and <<vol2_clause_dev_27_message_unsubscribe, {var_label_dev_27_message_unsubscribe}>> messages, which it responds to with <<vol2_clause_dev_27_message_subscribe_response, {var_label_dev_27_message_subscribe_response}>>, <<vol2_clause_dev_27_message_renew_response, {var_label_dev_27_message_renew_response}>> or <<vol2_clause_dev_27_message_unsubscribe_response, {var_label_dev_27_message_unsubscribe_response}>> messages respectively.
 
-While a subscription is running, the <<actor_somds_provider>> delivers <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
+While a subscription is running, the <<vol1_spec_sdpi_p_actor_somds_provider>> delivers <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
 
-When at some point the subscription has to be ended, the <<actor_somds_provider>> sends a <<vol2_clause_dev_27_message_subscription_end, {var_label_dev_27_message_subscription_end}>> message.
+When at some point the subscription has to be ended, the <<vol1_spec_sdpi_p_actor_somds_provider>> sends a <<vol2_clause_dev_27_message_subscription_end, {var_label_dev_27_message_subscription_end}>> message.
 
 |===
 
@@ -61,12 +61,12 @@ CAUTION: Transaction {var_transaction_id} supports a general <<vol2_clause_dev_2
 [#vol2_clause_dev_27_message_subscribe]
 ===== {var_label_dev_27_message_subscribe} Message
 
-The {var_label_dev_27_message_subscribe} message is sent as part of the BICEPS publish-subscribe and streaming message exchange for allowing <<actor_somds_consumer>>s to subscribe to data changes of <<actor_somds_provider>>s.
+The {var_label_dev_27_message_subscribe} message is sent as part of the BICEPS publish-subscribe and streaming message exchange for allowing <<vol1_spec_sdpi_p_actor_somds_consumer>>s to subscribe to data changes of <<vol1_spec_sdpi_p_actor_somds_provider>>s.
 
 [#vol2_clause_dev_27_message_subscribe_trigger_events]
 ====== Trigger Events
 
-The {var_label_dev_27_message_subscribe} message is sent whenever a <<actor_somds_consumer>> intends to get notified on certain changes of a <<actor_somds_provider>> comprising
+The {var_label_dev_27_message_subscribe} message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_consumer>> intends to get notified on certain changes of a <<vol1_spec_sdpi_p_actor_somds_provider>> comprising
 
 - publish-subscribe message exchange and
 - stream message exchange.
@@ -90,7 +90,7 @@ The {var_label_dev_27_message_subscribe} message is sent whenever a <<actor_somd
 [#vol2_clause_dev_27_message_subscribe_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_consumer>> sends this message, the receiving <<actor_somds_provider>> responds with a <<vol2_clause_dev_27_message_subscribe_response, {var_label_dev_27_message_subscribe_response}>> message.
+When a <<vol1_spec_sdpi_p_actor_somds_consumer>> sends this message, the receiving <<vol1_spec_sdpi_p_actor_somds_provider>> responds with a <<vol2_clause_dev_27_message_subscribe_response, {var_label_dev_27_message_subscribe_response}>> message.
 
 
 // ---------- SUBSCRIBE RESPONSE ---------
@@ -104,20 +104,20 @@ The {var_label_dev_27_message_subscribe_response} message is sent as part of the
 [#vol2_clause_dev_27_message_subscribe_response_trigger_events]
 ====== Trigger Events
 
-The {var_label_dev_27_message_subscribe_response} message is sent whenever a <<actor_somds_provider>> receives a <<vol2_clause_dev_27_message_subscribe, {var_label_dev_27_message_subscribe}>> message.
+The {var_label_dev_27_message_subscribe_response} message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> receives a <<vol2_clause_dev_27_message_subscribe, {var_label_dev_27_message_subscribe}>> message.
 
 [#vol2_clause_dev_27_message_probe_match_semantics]
 ====== Message Semantics
 
-[[payload_dev_27_subscribe_response_subscription_manager]]Subscription Manager:: Dedicated instance that manages the subscription, i.e. allows for a <<actor_somds_consumer>> to renew or cancel the subscription.
+[[payload_dev_27_subscribe_response_subscription_manager]]Subscription Manager:: Dedicated instance that manages the subscription, i.e. allows for a <<vol1_spec_sdpi_p_actor_somds_consumer>> to renew or cancel the subscription.
 [[payload_dev_27_subscribe_response_expiration_time]]Expiration Time:: Actual expiration time, which does not necessarily equal the requested expiration time.
 
 [#vol2_clause_dev_27_message_probe_match_expected_actions]
 ====== Expected Actions
 
-The <<actor_somds_consumer>> that receives a {var_label_dev_27_message_subscribe_response} message can use the <<payload_dev_27_subscribe_response_subscription_manager>> to renew the subscription shortly before the <<payload_dev_27_subscribe_response_expiration_time>> exceeds or cancel the subscription if it is no longer interested in updates.
+The <<vol1_spec_sdpi_p_actor_somds_consumer>> that receives a {var_label_dev_27_message_subscribe_response} message can use the <<payload_dev_27_subscribe_response_subscription_manager>> to renew the subscription shortly before the <<payload_dev_27_subscribe_response_expiration_time>> exceeds or cancel the subscription if it is no longer interested in updates.
 
-Once received, the <<actor_somds_consumer>> listens for <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
+Once received, the <<vol1_spec_sdpi_p_actor_somds_consumer>> listens for <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
 
 
 // ---------- NOTIFICATION ---------
@@ -126,24 +126,24 @@ Once received, the <<actor_somds_consumer>> listens for <<vol2_clause_dev_27_mes
 [#vol2_clause_dev_27_message_notification]
 ===== {var_label_dev_27_message_notification} Message
 
-The {var_label_dev_27_message_notification} message contains updated data and is delivered by a <<actor_somds_provider>> to subscribed <<actor_somds_consumer>>s.
+The {var_label_dev_27_message_notification} message contains updated data and is delivered by a <<vol1_spec_sdpi_p_actor_somds_provider>> to subscribed <<vol1_spec_sdpi_p_actor_somds_consumer>>s.
 
 The data items conveyed in {var_label_dev_27_message_notification} messages depend on the <<payload_dev_27_susbcribe_filter>> that was requested as part of the <<vol2_clause_dev_27_message_subscribe, {var_label_dev_27_message_subscribe}>> message.
 
 [#vol2_clause_dev_27_message_notification_trigger_events]
 ====== Trigger Events
 
-A {var_label_dev_27_message_notification} message is sent whenever a <<actor_somds_provider>> detects a change to its internal representation that is intended to be communicated to <<actor_somds_consumer>>s. The <<actor_somds_provider>> sends a {var_label_dev_27_message_notification} message to a <<actor_somds_consumer>> if and only if a matching <<payload_dev_27_susbcribe_filter>> has been requested by the <<actor_somds_consumer>>.
+A {var_label_dev_27_message_notification} message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> detects a change to its internal representation that is intended to be communicated to <<vol1_spec_sdpi_p_actor_somds_consumer>>s. The <<vol1_spec_sdpi_p_actor_somds_provider>> sends a {var_label_dev_27_message_notification} message to a <<vol1_spec_sdpi_p_actor_somds_consumer>> if and only if a matching <<payload_dev_27_susbcribe_filter>> has been requested by the <<vol1_spec_sdpi_p_actor_somds_consumer>>.
 
 [#vol2_clause_dev_27_message_notification_message_semantics]
 ====== Message Semantics
 
-[[payload_dev_27_payload]]Payload:: Payload specific to the <<payload_dev_27_susbcribe_filter>> that was subscribed by the <<actor_somds_consumer>> that receives the {var_label_dev_27_message_notification} message.
+[[payload_dev_27_payload]]Payload:: Payload specific to the <<payload_dev_27_susbcribe_filter>> that was subscribed by the <<vol1_spec_sdpi_p_actor_somds_consumer>> that receives the {var_label_dev_27_message_notification} message.
 
 [#vol2_clause_dev_27_message_notification_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_provider>> sends this message, there is no expected or required responses.
+When a <<vol1_spec_sdpi_p_actor_somds_provider>> sends this message, there is no expected or required responses.
 
 
 // ---------- RENEW ---------
@@ -162,13 +162,13 @@ The {var_label_dev_27_message_renew} message is sent whenever a subscription is 
 [#vol2_clause_dev_27_message_renew_message_semantics]
 ====== Message Semantics
 
-[[payload_dev_27_subscribe_response_subscription_manager]]Subscription Manager:: Dedicated instance that manages the subscription, i.e. allows for a <<actor_somds_consumer>> to renew or cancel the subscription.
+[[payload_dev_27_subscribe_response_subscription_manager]]Subscription Manager:: Dedicated instance that manages the subscription, i.e. allows for a <<vol1_spec_sdpi_p_actor_somds_consumer>> to renew or cancel the subscription.
 [[payload_dev_27_renew_expiration_time]]Expiration Time:: A new time requested for subscription expiration.
 
 [#vol2_clause_dev_27_message_renew_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_consumer>> sends this message, the receiving <<actor_somds_provider>> responds with a <<vol2_clause_dev_27_message_renew_response, {var_label_dev_27_message_renew_response}>> message.
+When a <<vol1_spec_sdpi_p_actor_somds_consumer>> sends this message, the receiving <<vol1_spec_sdpi_p_actor_somds_provider>> responds with a <<vol2_clause_dev_27_message_renew_response, {var_label_dev_27_message_renew_response}>> message.
 
 
 // ---------- RENEW RESPONSE ---------
@@ -182,7 +182,7 @@ The {var_label_dev_27_message_renew_response} message is sent as part of the BIC
 [#vol2_clause_dev_27_message_renew_response_trigger_events]
 ====== Trigger Events
 
-The {var_label_dev_27_message_renew_response} message is sent whenever a <<actor_somds_provider>> receives a <<vol2_clause_dev_27_message_renew, {var_label_dev_27_message_renew}>> message.
+The {var_label_dev_27_message_renew_response} message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> receives a <<vol2_clause_dev_27_message_renew, {var_label_dev_27_message_renew}>> message.
 
 [#vol2_clause_dev_27_message_renew_response_semantics]
 ====== Message Semantics
@@ -192,7 +192,7 @@ The {var_label_dev_27_message_renew_response} message is sent whenever a <<actor
 [#vol2_clause_dev_27_message_renew_response_expected_actions]
 ====== Expected Actions
 
-Once received, the <<actor_somds_consumer>> keeps listening for <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
+Once received, the <<vol1_spec_sdpi_p_actor_somds_consumer>> keeps listening for <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
 
 
 // ---------- UNSUBSCRIBE ---------
@@ -206,7 +206,7 @@ The {var_label_dev_27_message_unsubscribe} message is sent as part of the BICEPS
 [#vol2_clause_dev_27_message_unsubscribe_trigger_events]
 ====== Trigger Events
 
-The {var_label_dev_27_message_unsubscribe} message is sent by a <<actor_somds_consumer>> whenever it intends to end a running subscription of a <<actor_somds_provider>>.
+The {var_label_dev_27_message_unsubscribe} message is sent by a <<vol1_spec_sdpi_p_actor_somds_consumer>> whenever it intends to end a running subscription of a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 [#vol2_clause_dev_27_message_unsubscribe_message_semantics]
 ====== Message Semantics
@@ -216,7 +216,7 @@ The {var_label_dev_27_message_unsubscribe} message is sent by a <<actor_somds_co
 [#vol2_clause_dev_27_message_unsubscribe_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_consumer>> sends this message, the receiving <<actor_somds_provider>> responds with a <<vol2_clause_dev_27_message_unsubscribe_response, {var_label_dev_27_message_unsubscribe_response}>> message.
+When a <<vol1_spec_sdpi_p_actor_somds_consumer>> sends this message, the receiving <<vol1_spec_sdpi_p_actor_somds_provider>> responds with a <<vol2_clause_dev_27_message_unsubscribe_response, {var_label_dev_27_message_unsubscribe_response}>> message.
 
 
 // ---------- UNSUBSCRIBE RESPONSE ---------
@@ -230,7 +230,7 @@ The {var_label_dev_27_message_unsubscribe_response} message is sent as part of t
 [#vol2_clause_dev_27_message_unsubscribe_response_trigger_events]
 ====== Trigger Events
 
-The {var_label_dev_27_message_unsubscribe_response} message is sent whenever a <<actor_somds_provider>> receives a <<vol2_clause_dev_27_message_unsubscribe, {var_label_dev_27_message_unsubscribe}>> message.
+The {var_label_dev_27_message_unsubscribe_response} message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> receives a <<vol2_clause_dev_27_message_unsubscribe, {var_label_dev_27_message_unsubscribe}>> message.
 
 [#vol2_clause_dev_27_message_unsubscribe_response_semantics]
 ====== Message Semantics
@@ -240,7 +240,7 @@ The {var_label_dev_27_message_unsubscribe_response} message does not contain any
 [#vol2_clause_dev_27_message_unsubscribe_response_expected_actions]
 ====== Expected Actions
 
-Once received, the <<actor_somds_consumer>> cannot expect any further incoming <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
+Once received, the <<vol1_spec_sdpi_p_actor_somds_consumer>> cannot expect any further incoming <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
 
 
 // ---------- SUBSCRIPTION END ---------
@@ -249,12 +249,12 @@ Once received, the <<actor_somds_consumer>> cannot expect any further incoming <
 [#vol2_clause_dev_27_message_subscription_end]
 ===== {var_label_dev_27_message_subscription_end} Message
 
-The {var_label_dev_27_message_subscription_end} is delivered by a <<actor_somds_provider>> to signify the expected or unexpected end of a subscription, e.g. due to a shutdown of the <<actor_somds_provider>>.
+The {var_label_dev_27_message_subscription_end} is delivered by a <<vol1_spec_sdpi_p_actor_somds_provider>> to signify the expected or unexpected end of a subscription, e.g. due to a shutdown of the <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 [#vol2_clause_dev_27_message_subscription_end_trigger_events]
 ====== Trigger Events
 
-A {var_label_dev_27_message_subscription_end} message is sent whenever a <<actor_somds_provider>> intends to communicate the end of a subscription.
+A {var_label_dev_27_message_subscription_end} message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> intends to communicate the end of a subscription.
 
 [#vol2_clause_dev_27_message_subscription_end_message_semantics]
 ====== Message Semantics
@@ -265,7 +265,7 @@ A {var_label_dev_27_message_subscription_end} message is sent whenever a <<actor
 [#vol2_clause_dev_27_message_subscription_end_expected_actions]
 ====== Expected Actions
 
-Once received, the <<actor_somds_consumer>> cannot expect any further incoming <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
+Once received, the <<vol1_spec_sdpi_p_actor_somds_consumer>> cannot expect any further incoming <<vol2_clause_dev_27_message_notification, {var_label_dev_27_message_notification}>> messages.
 
 [#vol2_clause_dev_27_manage_biceps_subscription_ses]
 include::../dev-x-default-ses-secured-mode.adoc[]

--- a/asciidoc/volume2/dev-28/tf2-dev-28.adoc
+++ b/asciidoc/volume2/dev-28/tf2-dev-28.adoc
@@ -23,7 +23,7 @@ include::tf2-dev-28-summary.adoc[]
 |Listens for a <<vol2_clause_dev_28_message_notification, {var_label_dev_28_message_contextreport}>> message to retrieve context updates.
 
 |<<vol1_spec_sdpi_p_actor_somds_provider>>
-|While a subscription is running, the <<actor_somds_provider>> delivers <<vol2_clause_dev_28_message_notification, {var_label_dev_28_message_contextreport}>> messages.
+|While a subscription is running, the <<vol1_spec_sdpi_p_actor_somds_provider>> delivers <<vol2_clause_dev_28_message_notification, {var_label_dev_28_message_contextreport}>> messages.
 
 |===
 
@@ -47,12 +47,12 @@ CAUTION: Transaction {var_transaction_id} supports a specialized instance of the
 [#vol2_clause_dev_28_message_notification]
 ===== {var_label_dev_28_message_contextreport} Message
 
-The {var_label_dev_28_message_contextreport} message contains updated context data and is delivered by a <<actor_somds_provider>> to subscribed <<actor_somds_consumer>>s.
+The {var_label_dev_28_message_contextreport} message contains updated context data and is delivered by a <<vol1_spec_sdpi_p_actor_somds_provider>> to subscribed <<vol1_spec_sdpi_p_actor_somds_consumer>>s.
 
 [#vol2_clause_dev_28_message_notification_trigger_events]
 ====== Trigger Events
 
-The {var_label_dev_28_message_contextreport} message is sent whenever a context of a <<actor_somds_provider>> is updated and a <<actor_somds_consumer>> is subscribed to context reports of a <<actor_somds_provider>>.
+The {var_label_dev_28_message_contextreport} message is sent whenever a context of a <<vol1_spec_sdpi_p_actor_somds_provider>> is updated and a <<vol1_spec_sdpi_p_actor_somds_consumer>> is subscribed to context reports of a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 [#vol2_clause_dev_28_message_notification_semantics]
 ====== Message Semantics
@@ -62,7 +62,7 @@ The {var_label_dev_28_message_contextreport} message is sent whenever a context 
 [#vol2_clause_dev_28_message_contextreport_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_provider>> sends this message, there is no expected action or required responses.
+When a <<vol1_spec_sdpi_p_actor_somds_provider>> sends this message, there is no expected action or required responses.
 
 [#vol2_clause_dev_28_notify_change_ses]
 include::../dev-x-default-ses-secured-mode.adoc[]

--- a/asciidoc/volume2/dev-29/tf2-ch-a-mdpws-dev-29.adoc
+++ b/asciidoc/volume2/dev-29/tf2-ch-a-mdpws-dev-29.adoc
@@ -64,7 +64,7 @@ include::../dev-a-default-trigger-events.adoc[]
 
 ====== Message Semantics
 
-`s12:Envelope/s12:Body/msg:EpisodicMetricReport`:: Updated metric information of a <<actor_somds_provider>>.
+`s12:Envelope/s12:Body/msg:EpisodicMetricReport`:: Updated metric information of a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 :var_expected_actions_ref: <<vol2_clause_dev_29_message_notification>>
 include::../dev-a-default-expected-actions.adoc[]
@@ -94,7 +94,7 @@ include::../dev-a-default-trigger-events.adoc[]
 
 ====== Message Semantics
 
-`s12:Envelope/s12:Body/msg:EpisodicComponentReport`:: Updated component information of a <<actor_somds_provider>>.
+`s12:Envelope/s12:Body/msg:EpisodicComponentReport`:: Updated component information of a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 :var_expected_actions_ref: <<vol2_clause_dev_29_message_notification>>
 include::../dev-a-default-expected-actions.adoc[]
@@ -123,7 +123,7 @@ include::../dev-a-default-trigger-events.adoc[]
 
 ====== Message Semantics
 
-`s12:Envelope/s12:Body/msg:WaveformStream`:: Waveform stream of a <<actor_somds_provider>>.
+`s12:Envelope/s12:Body/msg:WaveformStream`:: Waveform stream of a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 :var_expected_actions_ref: <<vol2_clause_dev_29_message_notification>>
 include::../dev-a-default-expected-actions.adoc[]

--- a/asciidoc/volume2/dev-30/tf2-ch-a-mdpws-dev-30.adoc
+++ b/asciidoc/volume2/dev-30/tf2-ch-a-mdpws-dev-30.adoc
@@ -59,9 +59,9 @@ include::../dev-a-default-trigger-events.adoc[]
 
 ====== Message Semantics
 
-`s12:Envelope/s12:Body/msg:GetMdibResponse/msg:Mdib/pm:MdDescription`:: The <<actor_somds_provider>>'s descriptive part of the MDIB.
+`s12:Envelope/s12:Body/msg:GetMdibResponse/msg:Mdib/pm:MdDescription`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s descriptive part of the MDIB.
 
-`s12:Envelope/s12:Body/msg:GetMdibResponse/msg:Mdib/pm:MdState`:: The <<actor_somds_provider>>'s state part of the MDIB.
+`s12:Envelope/s12:Body/msg:GetMdibResponse/msg:Mdib/pm:MdState`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s state part of the MDIB.
 
 :var_expected_actions_ref: <<vol2_clause_dev_30_message_getmdibresponse>>
 include::../dev-a-default-expected-actions.adoc[]
@@ -74,7 +74,7 @@ include::../dev-a-default-expected-actions.adoc[]
 .R7002
 [sdpi_requirement#r7002,sdpi_req_level=shall]
 ****
-A <<actor_somds_provider>> shall enclose all context states in pm:GetMdibResponse messages.
+A <<vol1_spec_sdpi_p_actor_somds_provider>> shall enclose all context states in pm:GetMdibResponse messages.
 
 .Notes
 [%collapsible]

--- a/asciidoc/volume2/dev-30/tf2-dev-30-summary.adoc
+++ b/asciidoc/volume2/dev-30/tf2-dev-30-summary.adoc
@@ -1,3 +1,3 @@
 // DEV-30 Transaction Summary
 
-Retrieve the MDIB of a <<actor_somds_provider>> a <<actor_somds_consumer>> is interested in.
+Retrieve the MDIB of a <<vol1_spec_sdpi_p_actor_somds_provider>> a <<vol1_spec_sdpi_p_actor_somds_consumer>> is interested in.

--- a/asciidoc/volume2/dev-30/tf2-dev-30.adoc
+++ b/asciidoc/volume2/dev-30/tf2-dev-30.adoc
@@ -19,10 +19,10 @@ include::tf2-dev-30-summary.adoc[]
 |===
 |Actor |Roles
 
-|<<actor_somds_consumer>>
-|Initiates communication by sending a <<vol2_clause_dev_30_message_getmdib, {var_label_dev_30_message_getmdib}>> message to a <<actor_somds_provider>>. Then listens for a <<vol2_clause_dev_30_message_getmdibresponse, {var_label_dev_30_message_getmdibresponse}>> message to retrieve the <<actor_somds_provider>>'s MDIB.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+|Initiates communication by sending a <<vol2_clause_dev_30_message_getmdib, {var_label_dev_30_message_getmdib}>> message to a <<vol1_spec_sdpi_p_actor_somds_provider>>. Then listens for a <<vol2_clause_dev_30_message_getmdibresponse, {var_label_dev_30_message_getmdibresponse}>> message to retrieve the <<vol1_spec_sdpi_p_actor_somds_provider>>'s MDIB.
 
-|<<actor_somds_provider>>
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
 |Listens for <<vol2_clause_dev_30_message_getmdib, {var_label_dev_30_message_getmdib}>> messages, which it responds to with <<vol2_clause_dev_30_message_getmdibresponse, {var_label_dev_30_message_getmdibresponse}>> messages respectively.
 
 |===
@@ -46,12 +46,12 @@ include::../../plantuml/vol2-figure-dev-30-sequence.puml[]
 [#vol2_clause_dev_30_message_getmdib]
 ===== {var_label_dev_30_message_getmdib} Message
 
-The {var_label_dev_30_message_getmdib} message is sent as part of the BICEPS GET SERVICE for allowing <<actor_somds_consumer>>s to retrieve the description and state of an MDIB from a <<actor_somds_provider>>.
+The {var_label_dev_30_message_getmdib} message is sent as part of the BICEPS GET SERVICE for allowing <<vol1_spec_sdpi_p_actor_somds_consumer>>s to retrieve the description and state of an MDIB from a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 [#vol2_clause_dev_30_message_getmdib_trigger_events]
 ====== Trigger Events
 
-The {var_label_dev_30_message_getmdib} message is sent whenever a <<actor_somds_consumer>> wants to retrieve the description and state of an MDIB of a <<actor_somds_provider>>.
+The {var_label_dev_30_message_getmdib} message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_consumer>> wants to retrieve the description and state of an MDIB of a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 [#vol2_clause_dev_30_message_getmdib_semantics]
 ====== Message Semantics
@@ -61,7 +61,7 @@ The {var_label_dev_30_message_getmdib} message does not contain any further sema
 [#vol2_clause_dev_30_message_getmdib_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_consumer>> sends this message, the receiving <<actor_somds_provider>> responds with a <<vol2_clause_dev_30_message_getmdibresponse, {var_label_dev_30_message_getmdibresponse}>> message.
+When a <<vol1_spec_sdpi_p_actor_somds_consumer>> sends this message, the receiving <<vol1_spec_sdpi_p_actor_somds_provider>> responds with a <<vol2_clause_dev_30_message_getmdibresponse, {var_label_dev_30_message_getmdibresponse}>> message.
 
 
 // ---------- Get Mdib Response ---------
@@ -76,7 +76,7 @@ The {var_label_dev_30_message_getmdibresponse} message is sent as part of the BI
 [#vol2_clause_dev_30_message_getmdibresponse_trigger_events]
 ====== Trigger Events
 
-The {var_label_dev_30_message_getmdibresponse} message is sent whenever a <<actor_somds_provider>> receives a <<vol2_clause_dev_30_message_getmdib, {var_label_dev_30_message_getmdib}>> message.
+The {var_label_dev_30_message_getmdibresponse} message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> receives a <<vol2_clause_dev_30_message_getmdib, {var_label_dev_30_message_getmdib}>> message.
 
 [#vol2_clause_dev_30_message_getmdibresponse_semantics]
 ====== Message Semantics
@@ -88,7 +88,7 @@ The {var_label_dev_30_message_getmdibresponse} message is sent whenever a <<acto
 [#vol2_clause_dev_30_message_getmdibresponse_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_provider>> sends this message, there is no expected or required response.
+When a <<vol1_spec_sdpi_p_actor_somds_provider>> sends this message, there is no expected or required response.
 
 [#vol2_clause_dev_30_retrieve_biceps_content_ses]
 include::../dev-x-default-ses-secured-mode.adoc[]

--- a/asciidoc/volume2/dev-34/tf2-ch-a-mdpws-dev-34.adoc
+++ b/asciidoc/volume2/dev-34/tf2-ch-a-mdpws-dev-34.adoc
@@ -30,7 +30,7 @@ include::../dev-a-default-trigger-events.adoc[]
 
 ====== Message Semantics
 
-`s12:Envelope/s12:Body/wsd:Bye/wsa:EndpointReference/wsa:Address`:: The <<actor_somds_provider>>'s <<payload_dev_34_provider_uid>> as URI.
+`s12:Envelope/s12:Body/wsd:Bye/wsa:EndpointReference/wsa:Address`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s <<payload_dev_34_provider_uid>> as URI.
 
 :var_expected_actions_ref: <<vol2_clause_dev_34_message_bye>>
 include::../dev-a-default-expected-actions.adoc[]

--- a/asciidoc/volume2/dev-34/tf2-dev-34-summary.adoc
+++ b/asciidoc/volume2/dev-34/tf2-dev-34-summary.adoc
@@ -1,3 +1,3 @@
 // DEV-34 Transaction Summary
 
-Notify all <<actor_somds_consumer>>s that a <<actor_somds_provider>> is leaving the network.
+Notify all <<vol1_spec_sdpi_p_actor_somds_consumer>>s that a <<vol1_spec_sdpi_p_actor_somds_provider>> is leaving the network.

--- a/asciidoc/volume2/dev-34/tf2-dev-34.adoc
+++ b/asciidoc/volume2/dev-34/tf2-dev-34.adoc
@@ -18,11 +18,11 @@ include::tf2-dev-34-summary.adoc[]
 |===
 |Actor |Roles
 
-|<<actor_somds_provider>>
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
 |Announces its departure by multicasting <<vol2_clause_dev_34_message_bye, {var_label_dev_34_message_bye}>> messages to all listening systems.
 
-|<<actor_somds_consumer>>
-|Listens for <<vol2_clause_dev_34_message_bye, {var_label_dev_34_message_bye}>> messages to identify any <<actor_somds_provider>>s that will leave the <<term_medical_device_lan>>.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+|Listens for <<vol2_clause_dev_34_message_bye, {var_label_dev_34_message_bye}>> messages to identify any <<vol1_spec_sdpi_p_actor_somds_provider>>s that will leave the <<term_medical_device_lan>>.
 
 |===
 
@@ -41,14 +41,14 @@ include::../../plantuml/vol2-figure-dev-34-sequence.puml[]
 [#vol2_clause_dev_34_message_bye]
 ===== {var_label_dev_34_message_bye} Message
 
-The {var_label_dev_34_message_bye} message is part of the BICEPS _implicit discovery_ protocol for allowing <<actor_somds_consumer>>s to receive a notification when a <<actor_somds_provider>> is leaving the network.
+The {var_label_dev_34_message_bye} message is part of the BICEPS _implicit discovery_ protocol for allowing <<vol1_spec_sdpi_p_actor_somds_consumer>>s to receive a notification when a <<vol1_spec_sdpi_p_actor_somds_provider>> is leaving the network.
 
-The {var_label_dev_34_message_bye} is a multicast message that is sent from each <<actor_somds_provider>> to all listening <<actor_somds_consumer>>s (zero to many).
+The {var_label_dev_34_message_bye} is a multicast message that is sent from each <<vol1_spec_sdpi_p_actor_somds_provider>> to all listening <<vol1_spec_sdpi_p_actor_somds_consumer>>s (zero to many).
 
 [#vol2_clause_dev_34_message_announce_network_departure_trigger_events]
 ====== Trigger Events
 
-This message is sent whenever a <<actor_somds_provider>> leaves a network.
+This message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> leaves a network.
 
 [#vol2_clause_dev_34_message_announce_network_departure_message_semantics]
 ====== Message Semantics
@@ -59,7 +59,7 @@ This message is sent whenever a <<actor_somds_provider>> leaves a network.
 [#vol2_clause_dev_34_message_announce_network_departure_expected_actions]
 ====== Expected Actions
 
-When a <<actor_somds_provider>> sends this message, there is no expected or required response.
+When a <<vol1_spec_sdpi_p_actor_somds_provider>> sends this message, there is no expected or required response.
 
 
 [#vol2_clause_dev_34_message_announce_network_departure_ses]

--- a/asciidoc/volume2/dev-35/tf2-dev-35-summary.adoc
+++ b/asciidoc/volume2/dev-35/tf2-dev-35-summary.adoc
@@ -1,3 +1,3 @@
 // DEV-35 Transaction Summary
 
-Establish the exchange of medical data between a <<actor_somds_provider>> and a <<actor_somds_consumer>>.
+Establish the exchange of medical data between a <<vol1_spec_sdpi_p_actor_somds_provider>> and a <<vol1_spec_sdpi_p_actor_somds_consumer>>.

--- a/asciidoc/volume2/dev-35/tf2-dev-35.adoc
+++ b/asciidoc/volume2/dev-35/tf2-dev-35.adoc
@@ -17,10 +17,10 @@ include::tf2-dev-35-summary.adoc[]
 [cols="1,2"]
 |===
 |Actor |Roles
-|<<actor_somds_consumer>>
-|Initiates communication by first subscribing to a <<actor_somds_provider>> by sending a {var_label_dev_35_message_subscribe} message.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+|Initiates communication by first subscribing to a <<vol1_spec_sdpi_p_actor_somds_provider>> by sending a {var_label_dev_35_message_subscribe} message.
 
-|<<actor_somds_provider>>
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
 |Listens for {var_label_dev_35_message_subscribe} messages, which it responds to with {var_label_dev_35_message_subscribe_response}.
 
 

--- a/asciidoc/volume2/dev-36/tf2-dev-36-summary.adoc
+++ b/asciidoc/volume2/dev-36/tf2-dev-36-summary.adoc
@@ -1,3 +1,3 @@
 // DEV-36 Transaction Summary
 
-Publish medical data from a <<actor_somds_provider>> to a <<actor_somds_consumer>>.
+Publish medical data from a <<vol1_spec_sdpi_p_actor_somds_provider>> to a <<vol1_spec_sdpi_p_actor_somds_consumer>>.

--- a/asciidoc/volume2/dev-36/tf2-dev-36.adoc
+++ b/asciidoc/volume2/dev-36/tf2-dev-36.adoc
@@ -16,11 +16,11 @@ include::tf2-dev-36-summary.adoc[]
 |===
 |Actor |Roles
 
-|<<actor_somds_consumer>>
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
 |Listens for a Notification message to retrieve medical data updates.
 
-|<<actor_somds_provider>>
-|While a subscription is running, the <<actor_somds_provider>> delivers Notification messages.
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
+|While a subscription is running, the <<vol1_spec_sdpi_p_actor_somds_provider>> delivers Notification messages.
 
 |===
 

--- a/asciidoc/volume2/dev-37/tf2-dev-37-summary.adoc
+++ b/asciidoc/volume2/dev-37/tf2-dev-37-summary.adoc
@@ -1,4 +1,4 @@
 // DEV-37 Transaction Summary
 
-Retrieve medical data from a <<actor_somds_provider>>.
+Retrieve medical data from a <<vol1_spec_sdpi_p_actor_somds_provider>>.
 

--- a/asciidoc/volume2/dev-37/tf2-dev-37.adoc
+++ b/asciidoc/volume2/dev-37/tf2-dev-37.adoc
@@ -17,10 +17,10 @@ include::tf2-dev-37-summary.adoc[]
 |===
 |Actor |Roles
 
-|<<actor_somds_consumer>>
-|Initiates communication by sending a {var_label_dev_37_message_getmdib} message to a <<actor_somds_provider>>. Then listens for a {var_label_dev_37_message_getmdibresponse} message to retrieve the <<actor_somds_provider>>'s MDIB.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+|Initiates communication by sending a {var_label_dev_37_message_getmdib} message to a <<vol1_spec_sdpi_p_actor_somds_provider>>. Then listens for a {var_label_dev_37_message_getmdibresponse} message to retrieve the <<vol1_spec_sdpi_p_actor_somds_provider>>'s MDIB.
 
-|<<actor_somds_provider>>
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
 |Listens for {var_label_dev_37_message_getmdib} messages, which it responds to with {var_label_dev_37_message_getmdibresponse} messages respectively.
 
 |===

--- a/asciidoc/volume2/dev-38/tf2-dev-38-summary.adoc
+++ b/asciidoc/volume2/dev-38/tf2-dev-38-summary.adoc
@@ -1,3 +1,3 @@
 // DEV-38 Transaction Summary
 
-Establish the exchange of medical alerts from a <<actor_somds_provider>> to a <<actor_somds_consumer>>.
+Establish the exchange of medical alerts from a <<vol1_spec_sdpi_p_actor_somds_provider>> to a <<vol1_spec_sdpi_p_actor_somds_consumer>>.

--- a/asciidoc/volume2/dev-38/tf2-dev-38.adoc
+++ b/asciidoc/volume2/dev-38/tf2-dev-38.adoc
@@ -16,10 +16,10 @@ include::tf2-dev-38-summary.adoc[]
 [cols="1,2"]
 |===
 |Actor |Roles
-|<<actor_somds_consumer>>
-|Initiates communication by first subscribing to a <<actor_somds_provider>> by sending a {var_label_dev_38_message_subscribe} message.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+|Initiates communication by first subscribing to a <<vol1_spec_sdpi_p_actor_somds_provider>> by sending a {var_label_dev_38_message_subscribe} message.
 
-|<<actor_somds_provider>>
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
 |Listens for {var_label_dev_38_message_subscribe} messages, which it responds to with {var_label_dev_38_message_subscribe_response}.
 
 

--- a/asciidoc/volume2/dev-39/tf2-dev-39-summary.adoc
+++ b/asciidoc/volume2/dev-39/tf2-dev-39-summary.adoc
@@ -1,3 +1,3 @@
 // DEV-39 Transaction Summary
 
-Notify a <<actor_somds_consumer>> about changes in the medical alert status of a <<actor_somds_provider>>.
+Notify a <<vol1_spec_sdpi_p_actor_somds_consumer>> about changes in the medical alert status of a <<vol1_spec_sdpi_p_actor_somds_provider>>.

--- a/asciidoc/volume2/dev-39/tf2-dev-39.adoc
+++ b/asciidoc/volume2/dev-39/tf2-dev-39.adoc
@@ -16,11 +16,11 @@ include::tf2-dev-39-summary.adoc[]
 |===
 |Actor |Roles
 
-|<<actor_somds_consumer>>
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
 |Listens for a Notification message to retrieve medical alert updates.
 
-|<<actor_somds_provider>>
-|While a subscription is running, the <<actor_somds_provider>> delivers Notification messages.
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
+|While a subscription is running, the <<vol1_spec_sdpi_p_actor_somds_provider>> delivers Notification messages.
 
 |===
 

--- a/asciidoc/volume2/dev-40/tf2-dev-40-summary.adoc
+++ b/asciidoc/volume2/dev-40/tf2-dev-40-summary.adoc
@@ -1,3 +1,3 @@
 // DEV-40 Transaction Summary
 
-Retrieve the medical alert status of a <<actor_somds_provider>>.
+Retrieve the medical alert status of a <<vol1_spec_sdpi_p_actor_somds_provider>>.

--- a/asciidoc/volume2/dev-40/tf2-dev-40.adoc
+++ b/asciidoc/volume2/dev-40/tf2-dev-40.adoc
@@ -18,10 +18,10 @@ include::tf2-dev-40-summary.adoc[]
 |===
 |Actor |Roles
 
-|<<actor_somds_consumer>>
-|Initiates communication by sending a {var_label_dev_40_message_getmdib} message to a <<actor_somds_provider>>. Then listens for a {var_label_dev_40_message_getmdibresponse} message to retrieve the <<actor_somds_provider>>'s MDIB.
+|<<vol1_spec_sdpi_p_actor_somds_consumer>>
+|Initiates communication by sending a {var_label_dev_40_message_getmdib} message to a <<vol1_spec_sdpi_p_actor_somds_provider>>. Then listens for a {var_label_dev_40_message_getmdibresponse} message to retrieve the <<vol1_spec_sdpi_p_actor_somds_provider>>'s MDIB.
 
-|<<actor_somds_provider>>
+|<<vol1_spec_sdpi_p_actor_somds_provider>>
 |Listens for {var_label_dev_40_message_getmdib} messages, which it responds to with {var_label_dev_40_message_getmdibresponse} messages respectively.
 
 |===

--- a/asciidoc/volume2/discovery-scopes/tf2-ch-a-mdpws-discovery-scopes.adoc
+++ b/asciidoc/volume2/discovery-scopes/tf2-ch-a-mdpws-discovery-scopes.adoc
@@ -3,14 +3,14 @@
 
 ==== Discovery Scopes
 
-<<ref_ieee_11073_20701_2018>> specifies requirements to the encoding of certain <<acronym_mdib>> data as WS-Discovery Scopes provided by <<actor_somds_provider>>s. This clause further details encoding rules for production specifications and attributes as laid out in the IEEE 11073-10101 nomenclature.
+<<ref_ieee_11073_20701_2018>> specifies requirements to the encoding of certain <<acronym_mdib>> data as WS-Discovery Scopes provided by <<vol1_spec_sdpi_p_actor_somds_provider>>s. This clause further details encoding rules for production specifications and attributes as laid out in the IEEE 11073-10101 nomenclature.
 
 ===== Encoding of Production Specifications
 
 .R0010
 [sdpi_requirement#r0010,sdpi_req_level=shall]
 ****
-If a <<term_manufacturer>> of a <<actor_somds_provider>> intends to include MDS production specifications in the WS-Discovery Scopes of the <<actor_somds_provider>>, the <<actor_somds_provider>> shall encode the production specifications by using the rules in <<vol2_listing_encoding_production_specification_mds>>.
+If a <<term_manufacturer>> of a <<vol1_spec_sdpi_p_actor_somds_provider>> intends to include MDS production specifications in the WS-Discovery Scopes of the <<vol1_spec_sdpi_p_actor_somds_provider>>, the <<vol1_spec_sdpi_p_actor_somds_provider>> shall encode the production specifications by using the rules in <<vol2_listing_encoding_production_specification_mds>>.
 
 .Notes
 [%collapsible]
@@ -68,7 +68,7 @@ NOTE: `ProductionSpecification` is specified in <<vol2_listing_encoding_producti
 .R0011
 [sdpi_requirement#r0011,sdpi_req_level=shall]
 ****
-If a <<term_manufacturer>> of a <<actor_somds_provider>> intends to include MDS attributes in the WS-Discovery Scopes of the <<actor_somds_provider>>, the <<actor_somds_provider>> shall encode the attributes by using the rules in <<vol2_listing_encoding_attribute_mds>>.
+If a <<term_manufacturer>> of a <<vol1_spec_sdpi_p_actor_somds_provider>> intends to include MDS attributes in the WS-Discovery Scopes of the <<vol1_spec_sdpi_p_actor_somds_provider>>, the <<vol1_spec_sdpi_p_actor_somds_provider>> shall encode the attributes by using the rules in <<vol2_listing_encoding_attribute_mds>>.
 
 .Notes
 [%collapsible]

--- a/asciidoc/volume2/gateways/tf2-ch-b-gateway-dec.adoc
+++ b/asciidoc/volume2/gateways/tf2-ch-b-gateway-dec.adoc
@@ -264,7 +264,7 @@ NOTE: For further information, please refer to the <<ref_ihe_pcd_tf_2_2019>>.
 [sdpi_requirement#r8005,sdpi_req_level=shall]
 ****
 
-For the IHE DEC profile, the <<actor_somds_dec_gateway>> shall set the OBR-4 field to the service identifier of the <<actor_somds_provider>>.
+For the IHE DEC profile, the <<actor_somds_dec_gateway>> shall set the OBR-4 field to the service identifier of the <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 .Notes
 [%collapsible]
@@ -474,7 +474,7 @@ NOTE: <<ref_tbl_dec_obx2_mapping>> defines the mapping of the SDC metric type to
 .R8011
 [sdpi_requirement#r8011,sdpi_req_level=shall]
 ****
-A <<actor_somds_dec_gateway>> shall leave the OBX-2 field empty for OBX segments defining the <<actor_somds_provider>>'s MDS, VMD, or CHAN containment tree elements.
+A <<actor_somds_dec_gateway>> shall leave the OBX-2 field empty for OBX segments defining the <<vol1_spec_sdpi_p_actor_somds_provider>>'s MDS, VMD, or CHAN containment tree elements.
 ****
 
 

--- a/asciidoc/volume2/gateways/tf2-ch-b-gateway-private-mdc-mapping.adoc
+++ b/asciidoc/volume2/gateways/tf2-ch-b-gateway-private-mdc-mapping.adoc
@@ -11,7 +11,7 @@ Please refer to <<ref_ieee_11073_10700_2022>> *TR1358* for further information.
 .R8119
 [sdpi_requirement#r8119,sdpi_req_level=shall,sdpi_max_occurrence=2]
 ****
-For each private code a <<actor_somds_provider>> shall provide exactly one *pm:Translation* where *pm:Translation/@Code* is identical with *pm:CodedValue/@Code*.
+For each private code a <<vol1_spec_sdpi_p_actor_somds_provider>> shall provide exactly one *pm:Translation* where *pm:Translation/@Code* is identical with *pm:CodedValue/@Code*.
 
 .Notes
 [%collapsible]

--- a/asciidoc/volume2/mdib-report-retrofit/tf2-ch-a-mdpws-mdib-report-retrofit.adoc
+++ b/asciidoc/volume2/mdib-report-retrofit/tf2-ch-a-mdpws-mdib-report-retrofit.adoc
@@ -1,18 +1,18 @@
 [#vol2_clause_appendix_a_mdib_report_retrofit]
 ==== MDIB Report Retrofit
 
-In addition to <<vol3_clause_mdib_report_retrofit>>, this section specifies requirements to an MDPWS transport binding. The requirements aim to verify that <<acronym_mdib>> versions received by a <<actor_somds_consumer>> are not decremented and present no gap.
+In addition to <<vol3_clause_mdib_report_retrofit>>, this section specifies requirements to an MDPWS transport binding. The requirements aim to verify that <<acronym_mdib>> versions received by a <<vol1_spec_sdpi_p_actor_somds_consumer>> are not decremented and present no gap.
 
 .R1001
 [sdpi_requirement#r1001,sdpi_req_level=shall]
 ****
-A <<actor_somds_provider>> shall only establish one TCP connection at a time for every subscribed <<actor_somds_consumer>>.
+A <<vol1_spec_sdpi_p_actor_somds_provider>> shall only establish one TCP connection at a time for every subscribed <<vol1_spec_sdpi_p_actor_somds_consumer>>.
 ****
 
 .R1002
 [sdpi_requirement#r1002,sdpi_req_level=shall]
 ****
-A <<actor_somds_participant>> shall utilize TCP to exchange messages with other <<actor_somds_participant>>s except for messages exchanged in the WS-Discovery Ad-hoc mode.
+A <<vol1_spec_sdpi_p_actor_somds_participant>> shall utilize TCP to exchange messages with other <<vol1_spec_sdpi_p_actor_somds_participant>>s except for messages exchanged in the WS-Discovery Ad-hoc mode.
 
 .Notes
 [%collapsible]
@@ -24,7 +24,7 @@ NOTE: The WS-Discovery Ad-hoc mode utilizes UDP to exchange messages, see <<ref_
 .R1003
 [sdpi_requirement#r1003,sdpi_req_level=shall]
 ****
-A <<actor_somds_participant>> shall only utilize HTTP 1.1 without HTTP pipelining for any HTTP traffic.
+A <<vol1_spec_sdpi_p_actor_somds_participant>> shall only utilize HTTP 1.1 without HTTP pipelining for any HTTP traffic.
 
 .Notes
 [%collapsible]
@@ -36,17 +36,17 @@ NOTE: Enforces use of HTTP 1.1 in order to limit choices by which a re-ordering 
 .R1004
 [sdpi_requirement#r1004,sdpi_req_level=shall]
 ****
-A <<actor_somds_provider>> shall transmit msg:WaveformStream, msg:AbstractMetricReport, msg:AbstractOperationalStateReport, msg:AbstractComponentReport, msg:AbstractAlertReport, msg:ObservedValueStream, msg:DescriptionModificationReport, and msg:AbstractContextReport messages sequentially.
+A <<vol1_spec_sdpi_p_actor_somds_provider>> shall transmit msg:WaveformStream, msg:AbstractMetricReport, msg:AbstractOperationalStateReport, msg:AbstractComponentReport, msg:AbstractAlertReport, msg:ObservedValueStream, msg:DescriptionModificationReport, and msg:AbstractContextReport messages sequentially.
 
 .Notes
 [%collapsible]
 ====
-NOTE: This allows for a <<actor_somds_consumer>> to apply report data on internal <<acronym_mdib>> data structures before receiving the next report without buffering.
+NOTE: This allows for a <<vol1_spec_sdpi_p_actor_somds_consumer>> to apply report data on internal <<acronym_mdib>> data structures before receiving the next report without buffering.
 ====
 ****
 
 .R1005
 [sdpi_requirement#r1005,sdpi_req_level=should]
 ****
-A <<actor_somds_consumer>> should reconnect or go into a fail-safe mode when it receives a report with an <<acronym_mdib>> version that is either lower than the last received version or more than one version higher than the last received version.
+A <<vol1_spec_sdpi_p_actor_somds_consumer>> should reconnect or go into a fail-safe mode when it receives a report with an <<acronym_mdib>> version that is either lower than the last received version or more than one version higher than the last received version.
 ****

--- a/asciidoc/volume2/mdpws-compression/tf2-ch-a-mdpws-compression.adoc
+++ b/asciidoc/volume2/mdpws-compression/tf2-ch-a-mdpws-compression.adoc
@@ -5,7 +5,7 @@ MDPWS <<ref_ieee_11073_20702_2016>> defines EXI as the designated means to compr
 .R0005
 [sdpi_requirement#r0005,sdpi_req_level=should]
 ****
-In its role as an HTTP client, a <<actor_somds_participant>> should request gzip compression by using Accept-Encoding with "gzip".
+In its role as an HTTP client, a <<vol1_spec_sdpi_p_actor_somds_participant>> should request gzip compression by using Accept-Encoding with "gzip".
 
 .Examples
 [%collapsible]
@@ -38,11 +38,11 @@ The HTTP server decided to encode the response with the gzip compression. Note t
 
 ====
 ****
-Unluckily, SDC makes heavy use of request payloads when delivering notifications. Hence, it is further recommended to allow for <<actor_somds_provider>>s to send compressed WS-Eventing Notification requests if a Subscribe request already included an accepted encoding.
+Unluckily, SDC makes heavy use of request payloads when delivering notifications. Hence, it is further recommended to allow for <<vol1_spec_sdpi_p_actor_somds_provider>>s to send compressed WS-Eventing Notification requests if a Subscribe request already included an accepted encoding.
 
 .R0006
 [sdpi_requirement#r0006,sdpi_req_level=may]
 ****
-If a <<actor_somds_consumer>> includes an Accept-Encoding header field in an HTTP header in a WS-Eventing Subscribe request, the <<actor_somds_provider>> may transmit Notifications related to that subscription encoded with the encoding that was defined in the Subscribe request.
+If a <<vol1_spec_sdpi_p_actor_somds_consumer>> includes an Accept-Encoding header field in an HTTP header in a WS-Eventing Subscribe request, the <<vol1_spec_sdpi_p_actor_somds_provider>> may transmit Notifications related to that subscription encoded with the encoding that was defined in the Subscribe request.
 ****
 

--- a/asciidoc/volume2/pretty-print/tf2-ch-a-mdpws-pretty-print.adoc
+++ b/asciidoc/volume2/pretty-print/tf2-ch-a-mdpws-pretty-print.adoc
@@ -10,7 +10,7 @@ However, if the serializer is not XML-Schema-agnostic, it ignores _mixed content
 [sdpi_requirement#r0013,sdpi_req_level=shall]
 ****
 
-A <<actor_somds_participant>> shall serialize XML instance documents in accordance to its applicable XML Schema definitions.
+A <<vol1_spec_sdpi_p_actor_somds_participant>> shall serialize XML instance documents in accordance to its applicable XML Schema definitions.
 
 .Notes
 [%collapsible]

--- a/asciidoc/volume2/service-mapping/tf2-ch-a-mdpws-service-mapping.adoc
+++ b/asciidoc/volume2/service-mapping/tf2-ch-a-mdpws-service-mapping.adoc
@@ -6,12 +6,12 @@ MDPWS is based on DPWS which in turn leverages a profiled SOAP-based Web Service
 .R0500
 [sdpi_requirement#r0500,sdpi_req_level=shall]
 ****
-A <<actor_somds_provider>> shall at least provide the port types as specified in <<vol2_table_appendix_mdpws_service_mapping_port_types>>.
+A <<vol1_spec_sdpi_p_actor_somds_provider>> shall at least provide the port types as specified in <<vol2_table_appendix_mdpws_service_mapping_port_types>>.
 
 .Notes
 [%collapsible]
 ====
-NOTE: According to <<acronym_biceps>>, the GET SERVICE is the only mandatory service to be implemented. This specification extends the list of mandatory services to increase interoperability between <<actor_somds_participant>>s.
+NOTE: According to <<acronym_biceps>>, the GET SERVICE is the only mandatory service to be implemented. This specification extends the list of mandatory services to increase interoperability between <<vol1_spec_sdpi_p_actor_somds_participant>>s.
 NOTE: All port types of SDC are {uri_sdc_wsdl}[available for download].
 
 NOTE: Other port types are currently out of scope of this specification and may be added in a future revision.
@@ -43,13 +43,13 @@ NOTE: Other port types are currently out of scope of this specification and may 
 .R0501
 [sdpi_requirement#r0501,sdpi_req_level=should]
 ****
-A <<actor_somds_consumer>> should not request context states by using the `GetContextStatesByIdentification` and `GetContextStatesByFilter` operations of the {{uri_sdc_port_type}}ContextService port type.
+A <<vol1_spec_sdpi_p_actor_somds_consumer>> should not request context states by using the `GetContextStatesByIdentification` and `GetContextStatesByFilter` operations of the {{uri_sdc_port_type}}ContextService port type.
 
 .Notes
 [%collapsible]
 ====
 NOTE: `GetContextStatesByIdentification` and `GetContextStatesByFilter` are insufficiently defined in <<ref_ieee_11073_10207_2017>> and are likely to be obsoleted in a future revision of the specification.
 
-NOTE: A <<actor_somds_consumer>> may retrieve context states by using `GetContextStates` and perform filtering by itself.
+NOTE: A <<vol1_spec_sdpi_p_actor_somds_consumer>> may retrieve context states by using `GetContextStates` and perform filtering by itself.
 ====
 ****

--- a/asciidoc/volume3/biceps-extension-provisions/tf3-ch-8.3.2.9-extension-equipment-identifier.adoc
+++ b/asciidoc/volume3/biceps-extension-provisions/tf3-ch-8.3.2.9-extension-equipment-identifier.adoc
@@ -4,7 +4,7 @@
 BICEPS does not provide means to convey any metadata that allows for identification of <<acronym_mds>>s or <<acronym_vmd>>s inside an <<acronym_mdib>> other than by UDIs.
 UDIs however are not unique when used in different jurisdictions or for multiple instances of a <<acronym_samd>>.
 
-This extension fulfills the need to identify <<acronym_mds>>s and <<acronym_vmd>>s across re-initializations of a <<actor_somds_provider>> by means of stable and globally unique URIs that are constant across re-initializations of the <<actor_somds_provider>>.
+This extension fulfills the need to identify <<acronym_mds>>s and <<acronym_vmd>>s across re-initializations of a <<vol1_spec_sdpi_p_actor_somds_provider>> by means of stable and globally unique URIs that are constant across re-initializations of the <<vol1_spec_sdpi_p_actor_somds_provider>>.
 
 [sdpi_level=+1]
 ====== Model
@@ -26,27 +26,27 @@ include::../../listings/vol3-clause-biceps-content-example-equipment-identifier.
 .R0014
 [sdpi_requirement#r0014,sdpi_req_level=shall]
 ****
-For the `sdpi:EquipmentIdentifier` extension, a <<actor_somds_provider>> shall use a stable, globally unique URI that is constant across re-initializations of the <<actor_somds_provider>> and uniquely refers to a physical or virtual entity.
+For the `sdpi:EquipmentIdentifier` extension, a <<vol1_spec_sdpi_p_actor_somds_provider>> shall use a stable, globally unique URI that is constant across re-initializations of the <<vol1_spec_sdpi_p_actor_somds_provider>> and uniquely refers to a physical or virtual entity.
 ****
 
 .R0015
 [sdpi_requirement#r0015,sdpi_req_level=should]
 ****
-For the `sdpi:EquipmentIdentifier` extension, a <<actor_somds_provider>> should use URI-encoded UUIDs or OIDs.
+For the `sdpi:EquipmentIdentifier` extension, a <<vol1_spec_sdpi_p_actor_somds_provider>> should use URI-encoded UUIDs or OIDs.
 ****
 
 .R0016
 [sdpi_requirement#r0016,sdpi_req_level=shall]
 ****
-To test if two equipment identifiers are equal, a <<actor_somds_participant>> shall perform case-sensitive string comparison.
+To test if two equipment identifiers are equal, a <<vol1_spec_sdpi_p_actor_somds_participant>> shall perform case-sensitive string comparison.
 ****
 
 .R0017
 [sdpi_requirement#r0017,sdpi_req_level=shall]
 ****
-A <<actor_somds_provider>> shall provide the `sdpi:EquipmentIdentifier` extension for each pm:MdsDescriptor in its <<acronym_mdib>>.
+A <<vol1_spec_sdpi_p_actor_somds_provider>> shall provide the `sdpi:EquipmentIdentifier` extension for each pm:MdsDescriptor in its <<acronym_mdib>>.
 
-NOTE: This requirement allows a <<actor_somds_consumer>> to rely on the `sdpi:EquipmentIdentifier` to be present in each <<acronym_mds>> at any time.
+NOTE: This requirement allows a <<vol1_spec_sdpi_p_actor_somds_consumer>> to rely on the `sdpi:EquipmentIdentifier` to be present in each <<acronym_mds>> at any time.
 
 NOTE: If a <<term_manufacturer>> provides a globally unique UDI, it can generate a the `sdpi:EquipmentIdentifier` UUID from that UDI. Alternatively, UUIDs can also be generated from UUIDv5 having a manufacturer specific namespace and the serial number as a name.
 ****
@@ -54,5 +54,5 @@ NOTE: If a <<term_manufacturer>> provides a globally unique UDI, it can generate
 .R0018
 [sdpi_requirement#r0018,sdpi_req_level=should]
 ****
-For each <<term_removable_subsystem>> <<acronym_vmd>> of a <<actor_somds_provider>>, the <<actor_somds_provider>> should provide the `sdpi:EquipmentIdentifier` extension for the pm:VmdDescriptor in its <<acronym_mdib>>.
+For each <<term_removable_subsystem>> <<acronym_vmd>> of a <<vol1_spec_sdpi_p_actor_somds_provider>>, the <<vol1_spec_sdpi_p_actor_somds_provider>> should provide the `sdpi:EquipmentIdentifier` extension for the pm:VmdDescriptor in its <<acronym_mdib>>.
 ****


### PR DESCRIPTION
@ToddCooper is it allowed to have forward references in TF-0 to TF-1? Currently, there are some references in TF-0 pointing to the actor chapters in TF-1. I can rollback to point to the TF-0 actor overview, though. Please let me know if that is required.