### PR TITLE
Added TF-3b for BICEPS Extension Namespace

### DIFF
--- a/asciidoc/sdpi-supplement-issues.adoc
+++ b/asciidoc/sdpi-supplement-issues.adoc
@@ -59,7 +59,9 @@ https://github.com/IHE/sdpi-fhir/issues/33[Github Issue #33 _Topic: Connect Time
 
 * *Issue: _Info exchanged during unsecured discovery_*
 ** https://github.com/IHE/sdpi-fhir/issues/102[Github Issue #102 _Append TOI: Info exchanged during unsecured discovery_]
-** #Identify list of updates to this supplement w/ links#
+////
+TODO:  ** Identify list of updates to this supplement w/ links
+////
 
 * *Issue: _What is a Central?_*
 ** https://github.com/IHE/sdpi-fhir/issues/123[Github Issue #123 _Append TOI: What is a Central?_]

--- a/asciidoc/volume3/tf3-ch-b-biceps-extension-namespace.adoc
+++ b/asciidoc/volume3/tf3-ch-b-biceps-extension-namespace.adoc
@@ -1,54 +1,33 @@
 [appendix#vol3_appendix_b_biceps_extension_namespace,sdpi_offset=B]
 == BICEPS Extension Namespace
 
-All BICEPS model extensions should utilize the namespace extnension OIDs as specified below.
+Extensions to the BICEPS Participant and Message Model defined in this specification utilize the XML Schema target namespace URI `urn:oid:1.3.6.1.4.1.19376.1.6.2.10.1.1.1`, of which the OID is further detailed in <<vol3_table_sdpi_biceps_extension_namespace>>.
 
-IHE Devices domain Top-level OID (see https://wiki.ihe.net/index.php/OID_Registration[IHE Domain Namespaces wiki]):  1.3.6.1.4.1.19376.1.6
-
-See https://wiki.ihe.net/index.php/PCD_OID_Management[IHE DEV OID Identifier Management wiki page] for a more complete listing of OIDs within the IHE Devices namespace.
-
-<<vol3_table_sdpi_biceps_extension_namespace>> details the OID extensions for semantics related to the SDC BICEPS model.  (See <<ref_ieee_11073_10207_2017>>)
+IHE Devices domain top-level OIDs are available at the https://wiki.ihe.net/index.php/OID_Registration[IHE Domain Namespaces wiki].
+A comprehensive listing of OIDs within the IHE Devices namespace is shown at the https://wiki.ihe.net/index.php/PCD_OID_Management[IHE PCD OID Management wiki page].
 
 [#vol3_table_sdpi_biceps_extension_namespace]
-.SDPi BICEPS Extension Namespaces
-[%autowidth]
-[cols="2,^1,3"]
+.SDPi BICEPS Extension Namespace OID Assignment
+[cols="2,3,1",options="autowidth, header"]
 |===
-.^|*OID*
-.^|*Namespace*
-.^|*Notes*
-
-| 1.3.6.1.4.1.19376.1.6
-| IHE DEV
-| Namespace allocated for the IHE Devices domain
-
-| 1.3.6.1.4.1.19376.1.6.2
-| Profile
-| Profile specific OIDs
+| Primary identifier
+| Concept description
+| Secondary identifier
 
 | 1.3.6.1.4.1.19376.1.6.2.10
-| SDPi
-| Namespace for general SDPi identifiers; non-profile specific
+| Profile specific OID for SDPi
+| sdpi
 
 | 1.3.6.1.4.1.19376.1.6.2.10.1
-| Extensions
-|
+| Describes namespaces for different purposes as specified by its sub-nodes
+| namespaces
 
 | 1.3.6.1.4.1.19376.1.6.2.10.1.1
-| SDC BICEPS Extension
-| SDPi extension to the identifiers in the BICEPS model published in the <<ref_ieee_11073_10207_2017>> standard
+| Extensions to the BICEPS Participant and Message Model
+| biceps-extensions
 
-| 1.3.6.1.4.1.19376.1.6.2.10.1.1.x
-| Version
-| For example, Version 1 would be 1.3.6.1.4.1.19376.1.6.2.10.1.1.1
-
-| 1.3.6.1.4.1.19376.1.6.2.10.1.2
-| <tbd>
-| Other general SDPi extensions
-
+| 1.3.6.1.4.1.19376.1.6.2.10.1.1.1
+| Major version 1 for extensions to the BICEPS Participant and Message Model.
+  In order to avoid proliferation of OIDs below `1.3.6.1.4.1.19376.1.6.2.10.1.1`, versions are incremented only if incompatible changes are made to an extension.
+| version1
 |===
-
-////
-TODO:  Add the complete OID extensions and updates SOMEWHERE in the SDPi profiles.  This appendix may be as good as it gets.
-////
-

--- a/asciidoc/volume3/tf3-ch-b-biceps-extension-namespace.adoc
+++ b/asciidoc/volume3/tf3-ch-b-biceps-extension-namespace.adoc
@@ -1,0 +1,54 @@
+[appendix#vol3_appendix_b_biceps_extension_namespace,sdpi_offset=B]
+== BICEPS Extension Namespace
+
+All BICEPS model extensions should utilize the namespace extnension OIDs as specified below.
+
+IHE Devices domain Top-level OID (see https://wiki.ihe.net/index.php/OID_Registration[IHE Domain Namespaces wiki]):  1.3.6.1.4.1.19376.1.6
+
+See https://wiki.ihe.net/index.php/PCD_OID_Management[IHE DEV OID Identifier Management wiki page] for a more complete listing of OIDs within the IHE Devices namespace.
+
+<<vol3_table_sdpi_biceps_extension_namespace>> details the OID extensions for semantics related to the SDC BICEPS model.  (See <<ref_ieee_11073_10207_2017>>)
+
+[#vol3_table_sdpi_biceps_extension_namespace]
+.SDPi BICEPS Extension Namespaces
+[%autowidth]
+[cols="2,^1,3"]
+|===
+.^|*OID*
+.^|*Namespace*
+.^|*Notes*
+
+| 1.3.6.1.4.1.19376.1.6
+| IHE DEV
+| Namespace allocated for the IHE Devices domain
+
+| 1.3.6.1.4.1.19376.1.6.2
+| Profile
+| Profile specific OIDs
+
+| 1.3.6.1.4.1.19376.1.6.2.10
+| SDPi
+| Namespace for general SDPi identifiers; non-profile specific
+
+| 1.3.6.1.4.1.19376.1.6.2.10.1
+| Extensions
+|
+
+| 1.3.6.1.4.1.19376.1.6.2.10.1.1
+| SDC BICEPS Extension
+| SDPi extension to the identifiers in the BICEPS model published in the <<ref_ieee_11073_10207_2017>> standard
+
+| 1.3.6.1.4.1.19376.1.6.2.10.1.1.x
+| Version
+| For example, Version 1 would be 1.3.6.1.4.1.19376.1.6.2.10.1.1.1
+
+| 1.3.6.1.4.1.19376.1.6.2.10.1.2
+| <tbd>
+| Other general SDPi extensions
+
+|===
+
+////
+TODO:  Add the complete OID extensions and updates SOMEWHERE in the SDPi profiles.  This appendix may be as good as it gets.
+////
+

--- a/asciidoc/volume3/tf3-main.adoc
+++ b/asciidoc/volume3/tf3-main.adoc
@@ -143,3 +143,5 @@ include::tf3-ch-8.7.3-physiologic-monitor.adoc[]
 include::tf3-ch-8.7.4-surgical.adoc[]
 
 include::tf3-ch-a-xml-schemas.adoc[]
+
+include::tf3-ch-b-biceps-extension-namespace.adoc[]


### PR DESCRIPTION
Added TF-3 Appendix B for IHE DEV OID namespace extensions. Also cleaned up a related "highlight" in the supplement issues section.

Closes #47 

## 📑 Description
Added TF-3 Appendix B BICEPS Namespace Extensions.

## ℹ Additional Information
The information in Appendix B is more than the absolute minimum necessary; however, it is currently the only place in the SDPi supplement where we even address OID extensions as resolved in previous meetings (see [Gemini 2022-04-08 SDPi Friday meeting notes, section 3.a.v](https://confluence.hl7.org/x/8i_kBQ)).  A TODO: was added at the end of the appendix indicating the need to flesh out detail in the table SOMEWHERE in the SDPi profiles.
