### PR TITLE
139 remove highlighting in closed issues section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,21 @@ and this project adheres to the following versioning scheme describe in the [SDP
 
 The SDPi changelog shall not contain the following sections
    - Deprecated
-   - Fixed
    - Security
 
-Each section shall contain a list of action items of the following format: `<brief one-sentence description of what has been done> (#<issue number>).`
+Each section shall contain a list of action items of the following format: `<brief one-sentence description of what has been done> (#<issue number & URL>).`
 
 ## [Unreleased]
 
 ### Added
 
 ### Changed
-
-- Wrong appendix numbering offset in tables to be aligned with appendix letter (#134).
-- Path to XML file to correctly render Figure 3:8.7.3.17-1 Physiologic Monitor Containment Tree Example (#136).
+- Replaced high-lighting from "Closed Issues" section with correct list  ([#139](https://github.com/IHE/DEV.SDPi/issues/139)) 
 
 ### Removed
+
+### Editorial Fixes
+- Wrong appendix numbering offset in tables to be aligned with appendix letter ([#134](https://github.com/IHE/DEV.SDPi/issues/134)).
+- Path to XML file to correctly render Figure 3:8.7.3.17-1 Physiologic Monitor Containment Tree Example ([#136](https://github.com/IHE/DEV.SDPi/issues/136)).
+- Corrected the PUML file name in TF-1:12.1.1-1 SDPi-A to render the alert reporting sequence diagram ([#135](https://github.com/IHE/DEV.SDPi/issues/135))
+

--- a/asciidoc/sdpi-supplement-issues.adoc
+++ b/asciidoc/sdpi-supplement-issues.adoc
@@ -44,8 +44,8 @@ For more detailed information on how the Gemini SES+MDI program manages issues f
 * *Issue: _Connect Time Delay Algorithm_*
 ** https://github.com/IHE/sdpi-fhir/issues/103[Github Issue #103 _Append TOI: Connect Time Delay Algorithm_] +
 https://github.com/IHE/sdpi-fhir/issues/33[Github Issue #33 _Topic: Connect Time Delay Algorithm_] +
-** Section added:  <<vol2_appendix_a_mdpws_messages>>, Amendments and Corrigenda, Connection Time Delay +
-SubscriptionEnd Message added to <<vol2_appendix_a_mdpws_messages>>, <<vol2_clause_appendix_mdpws_dev_27>>
+** Section added:  TF-2 Appendix A: Amendments and Corrigenda: Connection Time Delay;  +
+SubscriptionEnd Message added to <<vol2_clause_appendix_mdpws_dev_27>>
 
 * *Issue: _Handling missed discovery messages_*
 ** https://github.com/IHE/sdpi-fhir/issues/96[Github Issue #96 _Append TOI: Handling missed discovery messages_]

--- a/asciidoc/sdpi-supplement-issues.adoc
+++ b/asciidoc/sdpi-supplement-issues.adoc
@@ -44,8 +44,8 @@ For more detailed information on how the Gemini SES+MDI program manages issues f
 * *Issue: _Connect Time Delay Algorithm_*
 ** https://github.com/IHE/sdpi-fhir/issues/103[Github Issue #103 _Append TOI: Connect Time Delay Algorithm_] +
 https://github.com/IHE/sdpi-fhir/issues/33[Github Issue #33 _Topic: Connect Time Delay Algorithm_] +
-##IS ONE OF THE ABOVE ISSUES STALE?##
-** #Identify list of updates to this supplement w/ links#
+** Section added:  <<vol2_appendix_a_mdpws_messages>>, Amendments and Corrigenda, Connection Time Delay +
+SubscriptionEnd Message added to <<vol2_appendix_a_mdpws_messages>>, <<vol2_clause_appendix_mdpws_dev_27>>
 
 * *Issue: _Handling missed discovery messages_*
 ** https://github.com/IHE/sdpi-fhir/issues/96[Github Issue #96 _Append TOI: Handling missed discovery messages_]
@@ -59,6 +59,7 @@ https://github.com/IHE/sdpi-fhir/issues/33[Github Issue #33 _Topic: Connect Time
 
 * *Issue: _Info exchanged during unsecured discovery_*
 ** https://github.com/IHE/sdpi-fhir/issues/102[Github Issue #102 _Append TOI: Info exchanged during unsecured discovery_]
+
 ////
 TODO:  ** Identify list of updates to this supplement w/ links
 ////


### PR DESCRIPTION

Closes #139 

## 📑 Description
Closed Issues text was highlighted vs. having the correct info added
changelog.md also updated as necessary
