### PR TITLE
Add csf risk requirements to sdp p ses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Each section shall contain a list of action items of the following format: `<bri
 - Changed use case _Devices are operational in the MD LAN network but cannot access the TS Service and clock drift is unacceptable_ so that the decision to continue/discontinue the execution of a System Function while the clocks become less accurate lies with the consumer ([#31](https://github.com/IHE/DEV.SDPi/issues/31)). 
 - Open/Closed Issues sections have been revised. Sections are now generated automatically from Github issues ([#20](https://github.com/IHE/DEV.SDPi/issues/20)).
 - Rephrase R1542 to make sure, that system functions not being available don't lead to unnecessary alarms ([#180] (https://github.com/IHE/DEV.SDPi/issues/180)). 
+- Moved requirements R1542 & R1543 to the SDPi-P SES / Effectiveness section from Github issues ([#182](https://github.com/IHE/DEV.SDPi/issues/182))
 
 ### Removed
 

--- a/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
+++ b/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
@@ -913,7 +913,25 @@ For additional guidance, see section <<vol1_clause_appendix_a_ses_considerations
 No additional safety requirements or considerations are identified for this technical framework element beyond those specified in the _<<acronym_ses>> General Considerations_ section above.
 
 ==== Effectiveness Requirements & Considerations
-No additional effectiveness requirements or considerations are identified for this technical framework element beyond those specified in the _<<acronym_ses>> General Considerations_ section above.
+
+===== Specific Risk Control Measures for <<vol1_spec_sdpi_p_actor_somds_consumer>>s
+
+.R1542
+[sdpi_requirement#r1542,sdpi_req_level=shall]
+****
+When a <<vol1_spec_sdpi_p_actor_somds_consumer>> disables one or more <<term_system_function_contribution>>s, the <<vol1_spec_sdpi_p_actor_somds_consumer>> shall inform the affected users.
+****
+
+.R1543
+[sdpi_requirement#r1543,sdpi_req_level=shall]
+****
+If a <<vol1_spec_sdpi_p_actor_somds_consumer>> disables one or more <<term_system_function_contribution>>s, the <<vol1_spec_sdpi_p_actor_somds_consumer>> shall create a log entry, noting the disabled <<term_system_function_contribution>>s as well as the cause for disabling them.
+****
+
+===== Additional Requirements
+
+Additional effectiveness requirements or considerations are identified for this technical framework element beyond those specified in the _<<acronym_ses>> General Considerations_ section above.
+
 ==== Security Requirements & Considerations
 Security is foundational for all interactions between <<vol1_spec_sdpi_p_actor_somds_participant>> Actors, with a clear distinction being made between information that may be exchanged outside of a secure connection (e.g., during network discovery transactions).
 Specific security technologies may vary based on the implementation technology being used, and will be detailed in the appropriate TF-2 technology specifications.
@@ -921,6 +939,7 @@ All transactions indicate whether they require secure or unsecured connections.
 
 For the default <<acronym_sdpi_p>> connectivity technology, namely ISO/IEEE 11073 <<term_service_oriented_device_connectivity>>, TLS 1.2 (or later versions) support is required (See <<ref_ieee_11073_20701_2018>> and <<ref_ieee_11073_20702_2016>>).
 Additional information and requirements may be provided in <<vol2_appendix_a_mdpws_messages>>.
+
 
 [#vol1_clause_sdpi_p_cross_profile_considerations]
 === SDPi-P Cross Profile Considerations

--- a/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
+++ b/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
@@ -928,7 +928,7 @@ When a <<vol1_spec_sdpi_p_actor_somds_consumer>> disables one or more <<term_sys
 If a <<vol1_spec_sdpi_p_actor_somds_consumer>> disables one or more <<term_system_function_contribution>>s, the <<vol1_spec_sdpi_p_actor_somds_consumer>> shall create a log entry, noting the disabled <<term_system_function_contribution>>s as well as the cause for disabling them.
 ****
 
-===== Additional Requirements
+===== General Risk Controls
 
 Additional effectiveness requirements or considerations are identified for this technical framework element beyond those specified in the _<<acronym_ses>> General Considerations_ section above.
 

--- a/asciidoc/volume1/tf1-ch-11-sdpi-r.adoc
+++ b/asciidoc/volume1/tf1-ch-11-sdpi-r.adoc
@@ -325,6 +325,7 @@ No additional effectiveness requirements or considerations are identified for th
 ==== Security Requirements & Considerations
 No additional security requirements and considerations are identified for this technical framework element beyond those provided by the  SDPi-P profile (see <<vol1_clause_appendix_a_ses_considerations_section_template>>), and those specified in the _<<acronym_ses>> General Considerations_ section above.
 
+[#vol1_clause_sdpi_r_cross_profile_considerations]
 === SDPi-R Cross Profile Considerations
 No additional cross profile considerations have been identified.
 

--- a/asciidoc/volume1/use-cases/tf1-ch-c-use-case-stad.adoc
+++ b/asciidoc/volume1/use-cases/tf1-ch-c-use-case-stad.adoc
@@ -217,16 +217,5 @@ If a <<vol1_spec_sdpi_p_actor_somds_consumer>> receives an <<term_medical_data_i
 If a <<vol1_spec_sdpi_p_actor_somds_consumer>>'s internal clock is no longer sufficient for at least one of its <<term_system_function_contribution>>s, the <<vol1_spec_sdpi_p_actor_somds_consumer>> shall disable all affected <<term_system_function_contribution>>s.
 ****
 
-.R1542
-[sdpi_requirement#r1542,sdpi_req_level=shall]
-****
-When a <<vol1_spec_sdpi_p_actor_somds_consumer>> disables one or more <<term_system_function_contribution>>s, the <<vol1_spec_sdpi_p_actor_somds_consumer>> shall inform the affected users.
-****
-
-.R1543
-[sdpi_requirement#r1543,sdpi_req_level=shall]
-****
-If a <<vol1_spec_sdpi_p_actor_somds_consumer>> disables one or more <<term_system_function_contribution>>s, the <<vol1_spec_sdpi_p_actor_somds_consumer>> shall create a log entry, noting the disabled <<term_system_function_contribution>>s as well as the cause for disabling them.
-****
 
 


### PR DESCRIPTION
## 📑 Description

Moved requirements R1542 and R1543 to the SDPi-P SES Effectiveness section (per #182)

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x ] Pull Request Assignee
  * [ ] Reviewer
