### PR TITLE
Publication 1.1 reference numbering issue

### DIFF
--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/ReferenceSanitizerPostprocessor.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/ReferenceSanitizerPostprocessor.kt
@@ -82,7 +82,7 @@ class ReferenceSanitizerPostprocessor(
 
             val anchorText = (encodedLabel?.let { decodeLabel(it) }) ?: item.refText
             when (item.source) {
-                LabelSource.SECTION -> anchor.text(anchorText ?: "$sectionSig${item.label}")
+                LabelSource.SECTION -> anchor.text(anchorText ?: "$sectionSig${item.prefix}:${item.label}")
                 LabelSource.TABLE_OR_FIGURE -> anchor.text(anchorText ?: item.label)
                 LabelSource.APPENDIX -> anchor.text(anchorText ?: "$appendixSig${item.prefix}:${item.label}")
                 LabelSource.VOLUME -> anchor.text(anchorText ?: "$chapterSig${item.prefix}")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,14 @@ Each section shall contain a list of action items of the following format: `<bri
 - Open/Closed Issues sections have been revised. Sections are now generated automatically from Github issues ([#20](https://github.com/IHE/DEV.SDPi/issues/20)).
 - Created a common section for the ACM and DEC gateways such that requirement numbers are not duplicated anymore ([#53](https://github.com/IHE/DEV.SDPi/issues/53).  
 - Rephrase R1542 to make sure, that system functions not being available don't lead to unnecessary alarms ([#180] (https://github.com/IHE/DEV.SDPi/issues/180)). 
-- Moved requirements R1542 & R1543 to the SDPi-P SES / Effectiveness section from Github issues ([#182](https://github.com/IHE/DEV.SDPi/issues/182))
-
+- Moved requirements R1542 & R1543 to the SDPi-P SES / Effectiveness section from Github issues ([#182](https://github.com/IHE/DEV.SDPi/issues/182)).
 
 ### Removed
 
 ### Editorial Fixes
 
-- Wrong appendix numbering in references ([#189](https://github.com/IHE/DEV.SDPi/issues/189))).
+- Wrong appendix numbering in references ([#189](https://github.com/IHE/DEV.SDPi/issues/189)).
+- Missing volume number in section references ([#189](https://github.com/IHE/DEV.SDPi/issues/189)).
 
 ## [1.0.1] - 2023-04-14
 


### PR DESCRIPTION
## 📑 Description

Fixes #189: n. Table 1:11.1-1, I think the references to the transactions should include the full location (e.g., Section 2:3-35), same for the other table, too

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
