### PR TITLE
Fix incorrect example action #292

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The SDPi changelog shall not contain the following sections
 Each section shall contain a list of action items of the following format: `<brief one-sentence description of what has been done> (#<issue number & URL>).`
 
 ## [Unreleased]
+- Fixed action URN in waveform stream example ([#292](https://github.com/IHE/DEV.SDPi/issues/292))
 
 ## [1.4.1] - 2024-10-04
 

--- a/asciidoc/listings/vol2-clause-appendix-a-mdpws-dev-29-waveformstream.xml
+++ b/asciidoc/listings/vol2-clause-appendix-a-mdpws-dev-29-waveformstream.xml
@@ -4,7 +4,7 @@
         xmlns:msg="http://standards.ieee.org/downloads/11073/11073-10207-2017/message"
         xmlns:wsa="http://www.w3.org/2005/08/addressing">
     <s12:Header>
-        <wsa:Action>http://standards.ieee.org/downloads/11073/11073-20701-2018/StateEventService/WaveformStream</wsa:Action>
+        <wsa:Action>http://standards.ieee.org/downloads/11073/11073-20701-2018/WaveformService/WaveformStream</wsa:Action>
         <wsa:MessageID><!-- ... --></wsa:MessageID>
         <wsa:To><!-- ... --></wsa:To>
     </s12:Header>


### PR DESCRIPTION
## 📑 Description

Figure 2:A.2.6.4.2-1. WaveformStream message example has the wrong action urn. 

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
