### PR TITLE
292 example message has wrong action urn for waveform stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The SDPi changelog shall not contain the following sections
 Each section shall contain a list of action items of the following format: `<brief one-sentence description of what has been done> (#<issue number & URL>).`
 
 ## [Unreleased]
+- Fixed action URN in waveform stream example ([#292](https://github.com/IHE/DEV.SDPi/issues/292))
 
 ## [1.4.1] - 2024-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The SDPi changelog shall not contain the following sections
 Each section shall contain a list of action items of the following format: `<brief one-sentence description of what has been done> (#<issue number & URL>).`
 
 ## [Unreleased]
+
+### Editorial Fixes
 - Fixed action URN in waveform stream example ([#292](https://github.com/IHE/DEV.SDPi/issues/292))
 
 ## [1.4.1] - 2024-10-04

--- a/asciidoc/listings/vol2-clause-appendix-a-mdpws-dev-29-waveformstream.xml
+++ b/asciidoc/listings/vol2-clause-appendix-a-mdpws-dev-29-waveformstream.xml
@@ -4,7 +4,7 @@
         xmlns:msg="http://standards.ieee.org/downloads/11073/11073-10207-2017/message"
         xmlns:wsa="http://www.w3.org/2005/08/addressing">
     <s12:Header>
-        <wsa:Action>http://standards.ieee.org/downloads/11073/11073-20701-2018/StateEventService/WaveformStream</wsa:Action>
+        <wsa:Action>http://standards.ieee.org/downloads/11073/11073-20701-2018/WaveformService/WaveformStream</wsa:Action>
         <wsa:MessageID><!-- ... --></wsa:MessageID>
         <wsa:To><!-- ... --></wsa:To>
     </s12:Header>


### PR DESCRIPTION
## 📑 Description

To resolve issue #292, this PR replaces the incorrect action URN (`http://standards.ieee.org/downloads/11073/11073-20701-2018/StateEventService/WaveformStream`) in the waveform stream example in Figure 2:A.2.6.4.2-1 with the correct one
(`http://standards.ieee.org/downloads/11073/11073-20701-2018/WaveformService/WaveformStream`) for the waveform stream operation of the the waveform service (11073-10207:§7.3.7). 

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
