### PR TITLE
Added SDPi FHIR Gateway with the reference to the HL7 FHIR PoCD IG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Each section shall contain a list of action items of the following format: `<bri
 - Clarified intentionality of difference between ad-hoc and managed discovery ([#317](https://github.com/IHE/DEV.SDPi/issues/317))
 - Clarified FHIR Gateway support for multiple paradigms ([#264](https://github.com/IHE/DEV.SDPi/issues/264))
 - Clarified that the SES sections are not comprehensive for risk management ([#271](https://github.com/IHE/DEV.SDPi/issues/271))
+- Added SDPi FHIR Gateway ([#252](https://github.com/IHE/DEV.SDPi/issues/252))
 
 ### Editorial Fixes
 - Added deprecation notice for three requirements due to expected impact of BICEPS standard corrigendum ([#334](https://github.com/IHE/DEV.SDPi/issues/334))

--- a/asciidoc/volume1/tf1-ch-12-sdpi-a.adoc
+++ b/asciidoc/volume1/tf1-ch-12-sdpi-a.adoc
@@ -240,7 +240,7 @@ Actor Summary Definition:
 [none]
 . A <<vol1_spec_sdpi_p_actor_somds_v2_gateway>> grouped actor that supports the bi-directional exchange of medical alert information with non-SOMDS systems and applications using IHE Alert Communication Management (ACM) transactions.
 
-This a is designed to exchange medical device alert information to external non-<<acronym_somds>> systems using the <<acronym_hl7>> V2-based Alert Communication Management (ACM) Profile transactions.
+This is designed to exchange medical device alert information to external non-<<acronym_somds>> systems using the <<acronym_hl7>> V2-based Alert Communication Management (ACM) Profile transactions.
 
 Every <<vol1_spec_sdpi_a_actor_somds_acm_gateway>> is grouped with an <<vol1_spec_sdpi_p_actor_somds_v2_gateway>> to enable <<acronym_somds>>-based connectivity.
 This actor inherits all the capabilities of the paired <<vol1_spec_sdpi_p_actor_somds_v2_gateway>>.

--- a/asciidoc/volume2/gateways/tf2-ch-b-gateway-fhir.adoc
+++ b/asciidoc/volume2/gateways/tf2-ch-b-gateway-fhir.adoc
@@ -1,0 +1,13 @@
+[#vol2_clause_appendix_sdpi_fhir_gateway]
+=== SDPi FHIR Gateway
+==== Scope
+This chapter defines the mapping from the <<acronym_mdib>> content as defined in this document and its underlying standards, to <<acronym_hl7>> <<acronym_fhir>> resources.
+
+The <<actor_somds_fhir_gateway>> represents a <<acronym_pocd>> data and/or alert reporter, which is defined in the <<ref_hl7_fhir_pocd_ig>>.
+
+The section https://build.fhir.org/ig/HL7/uv-pocd/mappingsdc.html[SDC to FHIR Mapping] of the <<ref_hl7_fhir_pocd_ig>> details the mapping from the <<acronym_mdib>> content to <<acronym_hl7>> <<acronym_fhir>> resources.
+
+==== Referenced Standards & Profiles
+This section provides an overview about the referenced standards and profiles used in this chapter:
+
+* <<ref_hl7_fhir_pocd_ig>>

--- a/asciidoc/volume2/tf2-ch-b-gateways.adoc
+++ b/asciidoc/volume2/tf2-ch-b-gateways.adoc
@@ -17,4 +17,7 @@ include::gateways/tf2-ch-b-gateway-dec.adoc[]
 // Gateway:  IHE DEV / PCD ACM Profile
 include::gateways/tf2-ch-b-gateway-acm.adoc[]
 
+// Gateway:  HL7 FHIR General Mappings
+include::gateways/tf2-ch-b-gateway-fhir.adoc[]
+
 


### PR DESCRIPTION
## 📑 Description

Added section SDPi FHIR Gateway in volume 2 under appendix B, which references to the HL7 FHIR PoCD implementation guide for the SDC to FHIR mapping.

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
