### PR TITLE
Added Unique Localized Text Catalog Identification section to volume 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Each section shall contain a list of action items of the following format: `<bri
 - Addressed three JIRA tickets listed in issue ([#275](https://github.com/IHE/DEV.SDPi/issues/275))
 - Corrected some entries in "1:B.1 Referenced Standards" for consistency ([#267](https://github.com/IHE/DEV.SDPi/issues/267))
 
+### Added
+- Unique identification of text catalog ([#256](https://github.com/IHE/DEV.SDPi/issues/256))
 
 ## [1.4.1] - 2024-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Each section shall contain a list of action items of the following format: `<bri
 
 ### Changes
 - Removed "and ignore" from BICEPS Content Consumer requirement ([#380](https://github.com/IHE/DEV.SDPi/issues/380))
+- Added new section "Unique Localized Text Catalog Identification" to volume 3 ([#256](https://github.com/IHE/DEV.SDPi/issues/256))
 ### Editorial Fixes
 - Corrected typos and grammar ([#363](https://github.com/IHE/DEV.SDPi/issues/363))
 ### Added

--- a/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
+++ b/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
@@ -23,4 +23,10 @@ A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZA
 NOTE: The version number can be part of unique text catalog identifier, e. g. the last sub-node of the *OID*. In this case, it is not necessary that the <<actor_somds_provider>> provides a text catalog verion number in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification*.
 ****
 
+.R0711
+[sdpi_requirement#r0711,sdpi_req_level=shall]
+****
+A <<actor_somds_provider>> that provides a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification* but does not support versioning of the text catalog shall provide a new unique text catalog identifier for each new version of the text catalog.
+****
+
 *TBD*: #which codes can be used for the text catalog id and the version in the ProductSpecification? Do we need new codes? Can we define SDPi OIDs or some similar for that?#

--- a/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
+++ b/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
@@ -1,33 +1,34 @@
 [#vol3_clause_localized_text_catalog_identification]
 ====== Unique Localized Text Catalog Identification
 
-In <<acronym_biceps>>, localized texts for parameter labels, alert strings, enumerations, etc. can be retrieved with the provided *LocalizedText/@Ref* (text id) and language code from the <<acronym_biceps>> Localization Service.
+In <<acronym_biceps>>, localized texts for parameter labels, alert strings, enumerations, etc. can be retrieved with the provided *LocalizedText/@Ref* (text id) and language code from the <<acronym_biceps>> *Localization Service*.
 
 
-Text ids are unique within a device scope. However, <<acronym_pocd>> vendors usually use the same text catalog for several of their products.
+Text ids are unique within a device scope. However, <<acronym_pocd>> vendors typically use the same text catalog for several of their products.
 
 In order to reduce the effort for a <<actor_somds_consumer>> for managing individual lookup tables per <<actor_somds_provider>>, a lookup table that resolves the text ids for multiple <<actor_somds_provider>> from the same <<acronym_pocd>> vendor is desirable for a <<actor_somds_consumer>>.
 
-.R0709
-[sdpi_requirement#r0709,sdpi_req_level=should]
+The following best practices are highly recommended when using text catalogs:
+
+.Recommentation A
 ****
-A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* should provide a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* list with *pm:ProductionSpecification+++<wbr/>+++/pm:SpecType+++<wbr/>+++/@Code = 68008 (MDC_ATTR_VMS_MDS_TEXT_CAT)*.
+A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* is supposed to provide a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* list with *pm:ProductionSpecification+++<wbr/>+++/pm:SpecType+++<wbr/>+++/@Code = 68008 (MDC_ATTR_VMS_MDS_TEXT_CAT)*.
 
 NOTE: The unique text catalog identifier defined in the corresponding *pm:ProductionSpecification+++<wbr/>+++/pm:ProductionSpec* can be an *urn* of type *uuid* or *oid*, e. g. *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1"*.
 ****
 
-.R0710
-[sdpi_requirement#r0710,sdpi_req_level=should]
+.Recommendation B
 ****
-A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* and supports versioning of the text catalog should provide a unique version number concatenated with the unique text catalog identifier and separated from the unique text catalog identifier by two colons (*"::"*) in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification+++<wbr/>+++/pm:ProductionSpec*.
+A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* and supports explicit versioning of the text catalog is supposed to provide a unique version number concatenated with the unique text catalog identifier and separated from the unique text catalog identifier by two colons (*"::"*) in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification+++<wbr/>+++/pm:ProductionSpec*.
 
 NOTE: *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1::v1.2.2*" is an example of a unique text catalog id with a concatenated text catalog version.
 
-NOTE: The version number can be part of unique text catalog identifier, e. g. the last sub-node of the *OID*. In this case, the requirement does not apply.
+NOTE: If the version number is already part of the unique text catalog identifier, e. g. the last sub-node of the *OID*, this recommenation does not apply.
 ****
 
-.R0711
-[sdpi_requirement#r0711,sdpi_req_level=shall]
+.Recommendation C
 ****
-A <<actor_somds_provider>> that provides a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* list but does not support versioning of the text catalog shall provide a new unique text catalog identifier for each new version of the text catalog.
+A <<actor_somds_provider>> that provides a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* needs to ensure that the unique text catalog identifier is updated when the text catalog has changed (e. g. due to a firmware update of device).
+
+NOTE: It is also important to ensure that the unique text catalog identifier is not the same as a text catalog identifier from a previous version of the text catalog.
 ****

--- a/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
+++ b/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
@@ -12,7 +12,7 @@ The set of all localized text strings with their unique text reference and langu
 
 The following best practices are highly recommended when using *TEXT CATALOGS*:
 
-.Recommentation A
+.Recommendation A
 ****
 A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* is supposed to provide a unique *TEXT CATALOG* identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* list with *pm:ProductionSpecification+++<wbr/>+++/pm:SpecType+++<wbr/>+++/@Code = 68008 (MDC_ATTR_VMS_MDS_TEXT_CAT)*.
 

--- a/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
+++ b/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
@@ -10,23 +10,23 @@ In order to reduce the effort for a <<actor_somds_consumer>> for managing indivi
 .R0709
 [sdpi_requirement#r0709,sdpi_req_level=should]
 ****
-A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* should provide a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification*.
+A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* should provide a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* list with *pm:ProductionSpecification+++<wbr/>+++/pm:SpecType+++<wbr/>+++/@Code = 68008 (MDC_ATTR_VMS_MDS_TEXT_CAT)*.
 
-NOTE: The unique text catalog identifier can be an *urn* of type *uuid* or *oid*, e. g. *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1"*.
+NOTE: The unique text catalog identifier defined in the corresponding *pm:ProductionSpecification+++<wbr/>+++/pm:ProductionSpec* can be an *urn* of type *uuid* or *oid*, e. g. *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1"*.
 ****
 
 .R0710
 [sdpi_requirement#r0710,sdpi_req_level=should]
 ****
-A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* and supports versioning of the text catalog should provide a unique version number along with the unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification*.
+A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* and supports versioning of the text catalog should provide a unique version number concatenated with the unique text catalog identifier and separated from the unique text catalog identifier by two colons (*"::"*) in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification+++<wbr/>+++/pm:ProductionSpec*.
 
-NOTE: The version number can be part of unique text catalog identifier, e. g. the last sub-node of the *OID*. In this case, it is not necessary that the <<actor_somds_provider>> provides a text catalog verion number in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification*.
+NOTE: *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1::v1.2.2*" is an example of a unique text catalog id with a concatenated text catalog version.
+
+NOTE: The version number can be part of unique text catalog identifier, e. g. the last sub-node of the *OID*. In this case, the requirement does not apply.
 ****
 
 .R0711
 [sdpi_requirement#r0711,sdpi_req_level=shall]
 ****
-A <<actor_somds_provider>> that provides a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification* but does not support versioning of the text catalog shall provide a new unique text catalog identifier for each new version of the text catalog.
+A <<actor_somds_provider>> that provides a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* list but does not support versioning of the text catalog shall provide a new unique text catalog identifier for each new version of the text catalog.
 ****
-
-*TBD*: #which codes can be used for the text catalog id and the version in the ProductSpecification? Do we need new codes? Can we define SDPi OIDs or some similar for that?#

--- a/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
+++ b/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
@@ -1,0 +1,26 @@
+[#vol3_clause_localized_text_catalog_identification]
+====== Unique Localized Text Catalog Identification
+
+In <<acronym_biceps>>, localized texts for parameter labels, alert strings, enumerations, etc. can be retrieved with the provided *LocalizedText/@ref* (text id) and language code from the <<acronym_biceps>> Localization Service.
+
+Text ids are unique within a device scope. However, <<acronym_pocd>> vendors usually use the same text catalog for several of their products.
+
+In order to reduce the effort for a <<actor_somds_consumer>> for managing individual lookup tables per <<actor_somds_provider>>, a lookup table that resolves the text ids for multiple <<actor_somds_provider>> from the same <<acronym_pocd>> vendor is desirable for a <<actor_somds_consumer>>.
+
+.R0709
+[sdpi_requirement#r0709,sdpi_req_level=should]
+****
+A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* should provide a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification*.
+
+NOTE: The unique text catalog identifier can be an *urn* of type *uuid* or *oid*, e. g. *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1"*.
+****
+
+.R0710
+[sdpi_requirement#r0710,sdpi_req_level=should]
+****
+A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* and supports versioning of the text catalog should provide a unique version number along with the unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification*.
+
+NOTE: The version number can be part of unique text catalog identifier, e. g. the last sub-node of the *OID*. In this case, it is not necessary that the <<actor_somds_provider>> provides a text catalog verion number in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification*.
+****
+
+*TBD*: #which codes can be used for the text catalog id and the version in the ProductSpecification? Do we need new codes? Can we define SDPi OIDs or some similar for that?#

--- a/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
+++ b/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
@@ -1,7 +1,8 @@
 [#vol3_clause_localized_text_catalog_identification]
 ====== Unique Localized Text Catalog Identification
 
-In <<acronym_biceps>>, localized texts for parameter labels, alert strings, enumerations, etc. can be retrieved with the provided *LocalizedText/@ref* (text id) and language code from the <<acronym_biceps>> Localization Service.
+In <<acronym_biceps>>, localized texts for parameter labels, alert strings, enumerations, etc. can be retrieved with the provided *LocalizedText/@Ref* (text id) and language code from the <<acronym_biceps>> Localization Service.
+
 
 Text ids are unique within a device scope. However, <<acronym_pocd>> vendors usually use the same text catalog for several of their products.
 

--- a/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
+++ b/asciidoc/volume3/biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc
@@ -1,34 +1,36 @@
 [#vol3_clause_localized_text_catalog_identification]
 ====== Unique Localized Text Catalog Identification
 
-In <<acronym_biceps>>, localized texts for parameter labels, alert strings, enumerations, etc. can be retrieved with the provided *LocalizedText/@Ref* (text id) and language code from the <<acronym_biceps>> *Localization Service*.
+In <<acronym_biceps>>, localized texts for parameter labels, alert strings, enumerations, etc. can be retrieved with the provided *LocalizedText/@Ref* (text reference) and language code from the <<acronym_biceps>> *LOCALIZATION SERVICE*.
 
 
-Text ids are unique within a device scope. However, <<acronym_pocd>> vendors typically use the same text catalog for several of their products.
+Text references are unique within a device scope. However, <<acronym_pocd>> vendors typically use the same text strings and text references for several of their products.
 
-In order to reduce the effort for a <<actor_somds_consumer>> for managing individual lookup tables per <<actor_somds_provider>>, a lookup table that resolves the text ids for multiple <<actor_somds_provider>> from the same <<acronym_pocd>> vendor is desirable for a <<actor_somds_consumer>>.
+In order to reduce the effort for a <<actor_somds_consumer>> for managing individual lookup tables per <<actor_somds_provider>>, a lookup table that resolves the text references for multiple <<actor_somds_provider>> from the same <<acronym_pocd>> vendor is desirable for a <<actor_somds_consumer>>.
 
-The following best practices are highly recommended when using text catalogs:
+The set of all localized text strings with their unique text reference and language code is referred to as "*TEXT CATALOG*" in the following paragraphs. When localized text strings have been added, changed, or deleted in the *TEXT CATALOG*, this is considered as a new version of the *TEXT CATALOG*.
+
+The following best practices are highly recommended when using *TEXT CATALOGS*:
 
 .Recommentation A
 ****
-A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* is supposed to provide a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* list with *pm:ProductionSpecification+++<wbr/>+++/pm:SpecType+++<wbr/>+++/@Code = 68008 (MDC_ATTR_VMS_MDS_TEXT_CAT)*.
+A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* is supposed to provide a unique *TEXT CATALOG* identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* list with *pm:ProductionSpecification+++<wbr/>+++/pm:SpecType+++<wbr/>+++/@Code = 68008 (MDC_ATTR_VMS_MDS_TEXT_CAT)*.
 
-NOTE: The unique text catalog identifier defined in the corresponding *pm:ProductionSpecification+++<wbr/>+++/pm:ProductionSpec* can be an *urn* of type *uuid* or *oid*, e. g. *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1"*.
+NOTE: The unique *TEXT CATALOG* identifier defined in the corresponding *pm:ProductionSpecification+++<wbr/>+++/pm:ProductionSpec* can be a URN of type *uuid* or *oid*, e. g. *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1"*.
 ****
 
 .Recommendation B
 ****
-A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* and supports explicit versioning of the text catalog is supposed to provide a unique version number concatenated with the unique text catalog identifier and separated from the unique text catalog identifier by two colons (*"::"*) in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification+++<wbr/>+++/pm:ProductionSpec*.
+A <<actor_somds_provider>> that has implemented the *<<acronym_biceps>> LOCALIZATION SERVICE* and supports explicit versioning of the *TEXT CATALOG* is supposed to provide a URN that includes the unique version number as part of the unique *TEXT CATALOG* identifier in the *pm:MdsDescriptor+++<wbr/>+++/ProductionSpecification+++<wbr/>+++/pm:ProductionSpec*.
 
-NOTE: *"urn:oid:1.3.6.1.4.1.1234.4.1.2.1::v1.2.2*" is an example of a unique text catalog id with a concatenated text catalog version.
+NOTE: "_urn:oid:1.3.6.1.4.1.1234.4.1.2_.*1.2.2*" is an example of a unique *TEXT CATALOG* id with the *TEXT CATALOG* version "*1.2.2*" added as additional nodes to the OID.
 
-NOTE: If the version number is already part of the unique text catalog identifier, e. g. the last sub-node of the *OID*, this recommenation does not apply.
+NOTE: If the version number is already part of the unique *TEXT CATALOG* identifier, e. g. the last sub-node of the *OID*, this recommenation does not apply.
 ****
 
 .Recommendation C
 ****
-A <<actor_somds_provider>> that provides a unique text catalog identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* needs to ensure that the unique text catalog identifier is updated when the text catalog has changed (e. g. due to a firmware update of device).
+A <<actor_somds_provider>> that provides a unique *TEXT CATALOG* identifier in the *pm:MdsDescriptor+++<wbr/>+++/pm:ProductionSpecification* needs to ensure that the unique *TEXT CATALOG* identifier is updated when the *TEXT CATALOG* has changed (e. g. due to a firmware update of device with modified localized text strings).
 
-NOTE: It is also important to ensure that the unique text catalog identifier is not the same as a text catalog identifier from a previous version of the text catalog.
+NOTE: It is also important to ensure that the unique *TEXT CATALOG* identifier is not the same as a *TEXT CATALOG* identifier from a previous version of the *TEXT CATALOG*.
 ****

--- a/asciidoc/volume3/tf3-ch-8.3.2-biceps-content.adoc
+++ b/asciidoc/volume3/tf3-ch-8.3.2-biceps-content.adoc
@@ -274,5 +274,7 @@ include::biceps-extension-provisions/tf3-ch-8.3.2.9.6-extension-equipment-identi
 
 include::biceps-content-module/tf3-ch-8.3.2.9.7-compound-metric-modelling.adoc[]
 
+include::biceps-content-module/tf3-ch-8.3.2.9.8-localized-text-catalog-identification.adoc[]
+
 // 8.3.2.10
 include::mdib-efficiency/tf3-ch-8.3.2.10-mdib-efficiency-considerations.adoc[]


### PR DESCRIPTION
## 📑 Description

Added Unique Localized Text Catalog Identification section to volume 3.

Proposal is to add the text catalog id and version to the MDS/ProductionSpecification.

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
