### PR TITLE
Updated `upload-artifact` to v4 as v3 is now deprecated.

### DIFF
--- a/.github/workflows/latest-master-build.yml
+++ b/.github/workflows/latest-master-build.yml
@@ -46,7 +46,7 @@ jobs:
       
     - name: Upload artifact
       # if: success() && github.ref == 'refs/heads/master'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sdpi-supplement
         path: sdpi-supplement

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,7 +46,7 @@ jobs:
       
     - name: Upload artifact
       # if: success() && github.ref == 'refs/heads/master'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sdpi-supplement
         path: sdpi-supplement


### PR DESCRIPTION
## 📑 Description

Updates CI workflow to use v4 `actions/upload-artifact` following [v3 deprecation](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). Follows approach taken in August 2024 with [feature-review-build.yml](https://github.com/IHE/DEV.SDPi/blob/8fda0cf43a95b5943a87c1b99e757fa45198ce2c/.github/workflows/feature-review-build.yml#L49) .

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
