### PR TITLE
SDPi-P SDC Gateway Direction Option + Editorial Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Each section shall contain a list of action items of the following format: `<bri
 ### Changes
 - Changed all references to IHE PCD TF 2019 to the newer 2024 version. Updated sections in document which were affected by the TF version change ([#340](https://github.com/IHE/DEV.SDPi/issues/340))
 - Removed transaction DEV-34 (Announce Network Departure) and updated references to future SDPi versions for maintainability ([#406](https://github.com/IHE/DEV.SDPi/issues/406))
+- Added SDPi-P SDC Gateway Direction profile option ([#396](https://github.com/IHE/DEV.SDPi/issues/396))
+- Profile Required Actor Groupings - Update with Table ([#387](https://github.com/IHE/DEV.SDPi/issues/387))
+- Add FHIR Gateway to the SDPi-R Actors table ([#388](https://github.com/IHE/DEV.SDPi/issues/388))
 
 ## [2.1.2] - 2025-05-09
 


### PR DESCRIPTION
## 📑 Description

Added support for SDC gateway actors to specify directionality (export, import, bidirectional).  Additional related editorial fixes added, such as FHIR Gateway callouts and Required Grouping information formatting.

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [ ] Pull Request Assignee
  * [ ] Reviewer
