### PR TITLE
Fix epochs schema to resolve double nesting of `sdpi:Epoch` element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Each section shall contain a list of action items of the following format: `<bri
 
 - Corrected three erroneous context-free codes in Table 3:8.3.2.10.2-1 ([#505](https://github.com/IHE/DEV.SDPi/issues/505))
 - Clarified referenced standards sections in 2:A and removed ISO prefix from IEEE/ISO standards for referential consistency ([#390](https://github.com/IHE/DEV.SDPi/issues/390))
+- Fixed TimeStampVersion.xsd to resolve double nesting of sdpi:Epoch element ([#520](https://github.com/IHE/DEV.SDPi/issues/520)). 
 
 ### Editorial Fixes
 

--- a/sources/extension-models/timestamp/TimeStampVersion.xsd
+++ b/sources/extension-models/timestamp/TimeStampVersion.xsd
@@ -68,8 +68,9 @@
                    maxOccurs="unbounded" />
     </xsd:sequence>
     <xsd:attribute name="Version"
+                   default="0"
                    type="sdpi:EpochVersion"
-                   use="required">
+                   use="optional">
       <xsd:annotation>
         <xsd:documentation>Current epoch version. Implied value is 0.</xsd:documentation>
       </xsd:annotation>

--- a/sources/extension-models/timestamp/TimeStampVersion.xsd
+++ b/sources/extension-models/timestamp/TimeStampVersion.xsd
@@ -48,7 +48,7 @@
   <!---->
   <!---->
   <!--Epochs-->
-  <xsd:element name="Epochs">
+  <xsd:element name="Epochs" type="sdpi:EpochsType">
     <xsd:annotation>
       <xsd:documentation>
         An extension to version epochs arising from non-slewing time adjustments.
@@ -56,16 +56,6 @@
         This extension can be attached to the pm:ClockState/ext:Extension element.
       </xsd:documentation>
     </xsd:annotation>
-    <xsd:complexType>
-      <xsd:sequence>
-        <xsd:element name="Epoch" type="sdpi:EpochsType" minOccurs="0" maxOccurs="unbounded" /> 
-      </xsd:sequence>
-      <xsd:attribute name="Version" type="sdpi:EpochVersion" use="required">
-        <xsd:annotation>
-          <xsd:documentation>Current epoch version. Implied value is 0.</xsd:documentation>
-        </xsd:annotation>
-      </xsd:attribute>
-    </xsd:complexType>
   </xsd:element>
   <xsd:complexType name="EpochsType">
     <xsd:annotation>
@@ -77,6 +67,13 @@
                    minOccurs="0"
                    maxOccurs="unbounded" />
     </xsd:sequence>
+    <xsd:attribute name="Version"
+                   type="sdpi:EpochVersion"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>Current epoch version. Implied value is 0.</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:complexType>
   <xsd:complexType name="EpochType">
     <xsd:annotation>

--- a/sources/extension-models/timestamp/TimeStampVersion.xsd
+++ b/sources/extension-models/timestamp/TimeStampVersion.xsd
@@ -78,20 +78,9 @@
     </xsd:annotation>
     <xsd:sequence>
       <xsd:element name="Epoch"
+                   type="sdpi:EpochType"
                    minOccurs="0"
-                   maxOccurs="unbounded">
-        <xsd:complexType>
-          <xsd:complexContent>
-            <xsd:extension base="sdpi:EpochType">
-              <xsd:attribute name="ext:MustUnderstant">
-                <xsd:annotation>
-                  <xsd:documentation>True if consumers are not permitted to use information from the MDIB if they do not understand the version indicated.</xsd:documentation>
-                </xsd:annotation>
-              </xsd:attribute>
-            </xsd:extension>
-          </xsd:complexContent>
-        </xsd:complexType>
-      </xsd:element>
+                   maxOccurs="unbounded" />
     </xsd:sequence>
     <xsd:attribute name="Version"
                    default="0"

--- a/sources/extension-models/timestamp/TimeStampVersion.xsd
+++ b/sources/extension-models/timestamp/TimeStampVersion.xsd
@@ -11,8 +11,7 @@
               namespace="http://standards.ieee.org/downloads/11073/11073-10207-2017/extension" />
   <xsd:import schemaLocation="../BICEPS_ParticipantModel.xsd"
               namespace="http://standards.ieee.org/downloads/11073/11073-10207-2017/participant" />
-  <xsd:element name="EpochSupport"
-               type="sdpi:EpochSupportType">
+  <xsd:element name="EpochSupport">
     <xsd:annotation>
       <xsd:documentation>
         An extension to indicate the MDIB may include versioned timestamps, particularly if an abrupt time adjustment occurs.
@@ -20,17 +19,23 @@
         This extension can be attached to the pm:ClockDescriptor descriptor.
       </xsd:documentation>
     </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="sdpi:EpochSupportType">
+          <xsd:attribute ref="ext:MustUnderstand"
+                         use="optional">
+            <xsd:annotation>
+              <xsd:documentation>True if consumers are not permitted to use information from the MDIB if they do not understand the version indicated. </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
   </xsd:element>
   <xsd:complexType name="EpochSupportType">
     <xsd:annotation>
       <xsd:documentation>Advises epoch versioning support level. </xsd:documentation>
     </xsd:annotation>
-    <xsd:attribute ref="ext:MustUnderstand"
-                   use="optional">
-      <xsd:annotation>
-        <xsd:documentation>True if consumers are not permitted to use information from the MDIB if they do not understand the version indicated. </xsd:documentation>
-      </xsd:annotation>
-    </xsd:attribute>
     <xsd:attribute name="Version"
                    default="1"
                    type="xsd:unsignedShort">
@@ -45,10 +50,8 @@
     </xsd:annotation>
     <xsd:restriction base="xsd:nonNegativeInteger" />
   </xsd:simpleType>
-  <!---->
-  <!---->
   <!--Epochs-->
-  <xsd:element name="Epochs" type="sdpi:EpochsType">
+  <xsd:element name="Epochs">
     <xsd:annotation>
       <xsd:documentation>
         An extension to version epochs arising from non-slewing time adjustments.
@@ -56,6 +59,18 @@
         This extension can be attached to the pm:ClockState/ext:Extension element.
       </xsd:documentation>
     </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="sdpi:EpochsType">
+          <xsd:attribute ref="ext:MustUnderstand"
+                         use="optional">
+            <xsd:annotation>
+              <xsd:documentation>True if consumers are not permitted to use information from the MDIB if they do not understand the version indicated.</xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
   </xsd:element>
   <xsd:complexType name="EpochsType">
     <xsd:annotation>
@@ -63,9 +78,20 @@
     </xsd:annotation>
     <xsd:sequence>
       <xsd:element name="Epoch"
-                   type="sdpi:EpochType"
                    minOccurs="0"
-                   maxOccurs="unbounded" />
+                   maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:complexContent>
+            <xsd:extension base="sdpi:EpochType">
+              <xsd:attribute name="ext:MustUnderstant">
+                <xsd:annotation>
+                  <xsd:documentation>True if consumers are not permitted to use information from the MDIB if they do not understand the version indicated.</xsd:documentation>
+                </xsd:annotation>
+              </xsd:attribute>
+            </xsd:extension>
+          </xsd:complexContent>
+        </xsd:complexType>
+      </xsd:element>
     </xsd:sequence>
     <xsd:attribute name="Version"
                    default="0"
@@ -86,8 +112,6 @@
         For example, if device time advanced by 1 hour in epoch 0 at 10 am, there will be an Epoch entry for epoch version 0 with a timestamp of 10am and Offset of +1 hour. The equivalent time in epoch version 1 will be 11 am.
       </xsd:documentation>
     </xsd:annotation>
-    <xsd:attribute ref="ext:MustUnderstand"
-                   use="optional" />
     <xsd:attribute name="Version"
                    use="required">
       <xsd:annotation>
@@ -113,7 +137,9 @@
     </xsd:attribute>
   </xsd:complexType>
   <xsd:attributeGroup name="EpochVersionGroup">
-    <xsd:attribute name="Clock" type="pm:HandleRef" use="optional" >
+    <xsd:attribute name="Clock"
+                   type="pm:HandleRef"
+                   use="optional">
       <xsd:annotation>
         <xsd:documentation>The clock versioned by this element. </xsd:documentation>
       </xsd:annotation>
@@ -131,19 +157,19 @@
     </xsd:annotation>
     <xsd:attributeGroup ref="sdpi:EpochVersionGroup" />
     <xsd:attribute name="DeterminationTime"
-                    type="sdpi:EpochVersion">
+                   type="sdpi:EpochVersion">
       <xsd:annotation>
         <xsd:documentation>Epoch version for the enclosing pm:AbstractMetricValue/@DeterminationTime. Implied value is current sdpi:Epochs/@Version.</xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
     <xsd:attribute name="StartTime"
-                    type="sdpi:EpochVersion">
+                   type="sdpi:EpochVersion">
       <xsd:annotation>
         <xsd:documentation>Epoch version for the enclosing pm:AbstractMetricValue/@StartTime. Implied value is current sdpi:Epochs/@Version.</xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
     <xsd:attribute name="StopTime"
-                    type="sdpi:EpochVersion">
+                   type="sdpi:EpochVersion">
       <xsd:annotation>
         <xsd:documentation>Epoch version for the enclosing pm:AbstractMetricValue/@StopTime. Implied value is current sdpi:Epochs/@Version.</xsd:documentation>
       </xsd:annotation>
@@ -161,7 +187,7 @@
     </xsd:annotation>
     <xsd:attributeGroup ref="sdpi:EpochVersionGroup" />
     <xsd:attribute name="Time"
-                       type="sdpi:EpochVersion">
+                   type="sdpi:EpochVersion">
       <xsd:annotation>
         <xsd:documentation>Epoch version for the enclosing pm:CalibrationInfo/@Time. Implied value is current sdpi:Epochs/@Version.</xsd:documentation>
       </xsd:annotation>
@@ -179,7 +205,7 @@
     </xsd:annotation>
     <xsd:attributeGroup ref="sdpi:EpochVersionGroup" />
     <xsd:attribute name="LastSelfCheck"
-                       type="sdpi:EpochVersion">
+                   type="sdpi:EpochVersion">
       <xsd:annotation>
         <xsd:documentation>Epoch version for the enclosing pm:AlertSystemState/@LastSelfCheck. Implied value is current sdpi:Epochs/@Version.</xsd:documentation>
       </xsd:annotation>
@@ -215,7 +241,7 @@
     </xsd:annotation>
     <xsd:attributeGroup ref="sdpi:EpochVersionGroup" />
     <xsd:attribute name="BindingStartTime"
-                       type="sdpi:EpochVersion">
+                   type="sdpi:EpochVersion">
       <xsd:annotation>
         <xsd:documentation>Epoch version for the enclosing pm:AbstractContextState/@BindingStartTime. Implied value is current sdpi:Epochs/@Version.</xsd:documentation>
       </xsd:annotation>


### PR DESCRIPTION
## 📑 Description

Resolves `TimeStampVersion.xsd` schema bug in #520 to avoid nesting `sdpi:Epoch` found by [Leon](https://github.com/leon1995). 

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
  * [x] Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
