### PR TITLE
Make DESCRIPTION EVENT SERVICE optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Each section shall contain a list of action items of the following format: `<bri
 ## Unreleased
 -->
 
+- Removed the DESCRIPTION EVENT SERVICE from list of minimum required services so consumers can determine the providers MdDescription can not change ([PR#](https://github.com/IHE/DEV.SDPi/pull/532)).
+
 ## [2.4.1] - 2026-05-07
 
 ### Editorial Fixes

--- a/asciidoc/volume2/dev-25/tf2-dev-25.adoc
+++ b/asciidoc/volume2/dev-25/tf2-dev-25.adoc
@@ -53,14 +53,16 @@ The GetMetadataResponse message is sent in response to an incoming <<vol2_clause
 The GetMetadataResponse message is sent whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> receives a <<vol2_clause_dev_25_message_get_metadata, GetMetadata>> message.
 
 ====== Message Semantics
-[[payload_dev_25_get_metadata_biceps_services]]BICEPS Services:: Collection of BICEPS services the <<vol1_spec_sdpi_p_actor_somds_provider>> offers, including but not limited to one or multiple of the following BICEPS services (<<ref_ieee_11073_10207_2017>> Section 7.3 Service Model):
+[[payload_dev_25_get_metadata_biceps_services]]BICEPS Services:: Collection of BICEPS services the <<vol1_spec_sdpi_p_actor_somds_provider>> offers, including but not limited to, one or more of the following BICEPS services (<<ref_ieee_11073_10207_2017>> Section 7.3 Service Model):
+
 * GET SERVICE (mandatory)
 * SET SERVICE
-* STATE EVENT SERVICE
-* CONTEXT SERVICE
-* WAVEFORM SERVICE
+* DESCRIPTION EVENT SERVICE
+* STATE EVENT SERVICE (required, see RefRequirement:r0500[])
+* CONTEXT SERVICE  (required, see RefRequirement:r0500[])
+* WAVEFORM SERVICE  (required, see RefRequirement:r0500[])
+* LOCALIZATION SERVICE
 
-NOTE: There is currently no mandatory support for provision of the DESCRIPTION EVENT SERVICE, LOCALIZATION SERVICE, CONTAINMENT TREE SERVICE and ARCHIVE SERVICE.
 
 [#message_semantics_discover_biceps_services_device]
 Device Metadata:: Expresses <<vol1_spec_sdpi_p_actor_somds_provider>> characteristics that typically vary from one <<vol1_spec_sdpi_p_actor_somds_provider>> to another of the same kind, for example:

--- a/asciidoc/volume2/dev-25/tf2-dev-25.adoc
+++ b/asciidoc/volume2/dev-25/tf2-dev-25.adoc
@@ -56,12 +56,11 @@ The GetMetadataResponse message is sent whenever a <<vol1_spec_sdpi_p_actor_somd
 [[payload_dev_25_get_metadata_biceps_services]]BICEPS Services:: Collection of BICEPS services the <<vol1_spec_sdpi_p_actor_somds_provider>> offers, including but not limited to one or multiple of the following BICEPS services (<<ref_ieee_11073_10207_2017>> Section 7.3 Service Model):
 * GET SERVICE (mandatory)
 * SET SERVICE
-* DESCRIPTION EVENT SERVICE
 * STATE EVENT SERVICE
 * CONTEXT SERVICE
 * WAVEFORM SERVICE
 
-NOTE: There is currently no mandatory support for provision of the LOCALIZATION SERVICE, CONTAINMENT TREE SERVICE and ARCHIVE SERVICE.
+NOTE: There is currently no mandatory support for provision of the DESCRIPTION EVENT SERVICE, LOCALIZATION SERVICE, CONTAINMENT TREE SERVICE and ARCHIVE SERVICE.
 
 [#message_semantics_discover_biceps_services_device]
 Device Metadata:: Expresses <<vol1_spec_sdpi_p_actor_somds_provider>> characteristics that typically vary from one <<vol1_spec_sdpi_p_actor_somds_provider>> to another of the same kind, for example:

--- a/asciidoc/volume2/service-mapping/tf2-ch-a-mdpws-service-mapping.adoc
+++ b/asciidoc/volume2/service-mapping/tf2-ch-a-mdpws-service-mapping.adoc
@@ -27,9 +27,6 @@ A <<vol1_spec_sdpi_p_actor_somds_provider>> shall at least provide the port type
 |++{++{uri_sdc_port_type}++}++GetService
 |GET SERVICE
 
-|++{++{uri_sdc_port_type}++}++DescriptionEventService
-|DESCRIPTION EVENT SERVICE
-
 |++{++{uri_sdc_port_type}++}++StateEventService
 |STATE EVENT SERVICE
 


### PR DESCRIPTION
## 📑 Description

Removed the DESCRIPTION EVENT SERVICE from list of minimum required services following brief discussion of #451 at PaT#23. 

Providers may still implement and offer this service, but aren't required to do so. Consumers that observe no DESCRIPTION EVENT SERVICE is offered may be confident that the provider won't be changing its medical device description at inconvenient times. 

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
  * [x] Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
