### PR TITLE
Clarified hello and bye notifications from discovery proxy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Each section shall contain a list of action items of the following format: `<bri
 ### Added
 
 - Clarification on SDPi-P safety requirements and considerations to explicitly include the application of the IEEE 11073-10700 standard ([#529](https://github.com/IHE/DEV.SDPi/issues/529))
-- Clarifies the use of `wsa:To` in greeting {`Hello`, `Bye`} notifications sent by a discovery proxy to a consumer ([#538](https://github.com/IHE/DEV.SDPi/pull/538)).
+- Clarifies the use of `wsa:To` in greeting {`Hello`, `Bye`} notifications sent by a discovery proxy to a consumer ([#534](https://github.com/IHE/DEV.SDPi/issues/534)).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Each section shall contain a list of action items of the following format: `<bri
 ### Added
 
 - Clarification on SDPi-P safety requirements and considerations to explicitly include the application of the IEEE 11073-10700 standard ([#529](https://github.com/IHE/DEV.SDPi/issues/529))
+- Clarifies the use of `wsa:To` in greeting {`Hello`, `Bye`} notifications sent by a discovery proxy to a consumer ([#538](https://github.com/IHE/DEV.SDPi/pull/538)).
 
 ### Changes
 

--- a/asciidoc/listings/vol2-clause-appendix-a-mdpws-dev-47-bye.xml
+++ b/asciidoc/listings/vol2-clause-appendix-a-mdpws-dev-47-bye.xml
@@ -6,7 +6,7 @@
     <s12:Header>
         <wsa:Action>http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Bye</wsa:Action>
         <wsa:MessageID><!-- ... --></wsa:MessageID>
-        <wsa:To>urn:docs-oasis-open-org:ws-dd:ns:discovery:2009:01</wsa:To>
+        <wsa:To><!-- evt:NotifyTo from subscription (optional) --></wsa:To>
     </s12:Header>
     <s12:Body>
         <wsd:Bye>

--- a/asciidoc/listings/vol2-clause-appendix-a-mdpws-dev-47-hello.xml
+++ b/asciidoc/listings/vol2-clause-appendix-a-mdpws-dev-47-hello.xml
@@ -8,15 +8,16 @@
     <s12:Header>
         <wsa:Action>http://docs.oasis-open.org/ws-dd/ns/discovery/2009/01/Hello</wsa:Action>
         <wsa:MessageID><!-- ... --></wsa:MessageID>
-        <wsa:To>urn:docs-oasis-open-org:ws-dd:ns:discovery:2009:01</wsa:To>
+        <wsa:To><!-- evt:NotifyTo from subscription (optional)--></wsa:To>
     </s12:Header>
     <s12:Body>
         <wsd:Hello>
             <wsa:EndpointReference>
-                <wsa:Address><!-- ... --></wsa:Address>
+                <wsa:Address><!-- Endpoint address of the provider --></wsa:Address>
             </wsa:EndpointReference>
             <wsd:Types>dpws:Device mdpws:MedicalDevice</wsd:Types>
             <wsd:Scopes>sdc.mds.pkp:1.2.840.10004.20701.1.1 <!-- ... --></wsd:Scopes>
+            <wsd:XAddrs><!-- Transport address of the provider --></wsd:XAddrs>
             <wsd:MetadataVersion><!-- ... --></wsd:MetadataVersion>
         </wsd:Hello>
     </s12:Body>

--- a/asciidoc/plantuml/vol1-figure-sdpi-p-managed-discovery-option-sequence-diagram.puml
+++ b/asciidoc/plantuml/vol1-figure-sdpi-p-managed-discovery-option-sequence-diagram.puml
@@ -28,6 +28,17 @@ somds_discovery_proxy  -->> somds_consumer: Return Network Presence
 
 end
 
+group secured (optional)
+
+somds_consumer ->> somds_discovery_proxy: Subscribe to Network Presence Notifications
+somds_discovery_proxy -->> somds_consumer: Subscribe Response
+
+loop Presence Change Notifications
+    somds_discovery_proxy -->> somds_consumer: Notify Network Presence change
+end
+
+end
+
 group secured
     somds_consumer -> somds_provider: Discover BICEPS Services
     somds_provider -->> somds_consumer

--- a/asciidoc/volume2/dev-47/tf2-ch-a-mdpws-dev-47.adoc
+++ b/asciidoc/volume2/dev-47/tf2-ch-a-mdpws-dev-47.adoc
@@ -12,11 +12,12 @@ This section specifies the MDPWS data transmission for messages defined in <<vol
 
 Additional implementation directions are defined in <<vol2_clause_appendix_mdpws_discovery_proxy>>.
 
-// ---------- Hello ---------
+// ---------- Hello from discovery proxy to consumer ---------
 
 ===== {var_label_dev_47_message_hello} Message
 
 The <<vol2_clause_dev_47_message_hello, {var_label_dev_47_message_hello}>> message is encoded by using {var_uri_dpws_messaging}[DPWS Messaging].
+The message body is encoded following the requirements for a unicast <<ref_oasis_ws_discovery_2009>> {var_label_dev_47_message_hello} message in managed mode to a <<vol1_spec_sdpi_p_actor_discovery_proxy>> (i.e., as if the <<vol1_spec_sdpi_p_actor_somds_consumer>> received the greeting information directly from the <<vol1_spec_sdpi_p_actor_somds_provider>>).
 
 ====== Referenced Standards
 
@@ -37,8 +38,12 @@ include::../dev-a-default-trigger-events.adoc[]
 
 ====== Message Semantics
 
-`s12:Envelope/s12:Body/wsd:Hello/wsa:EndpointReference/wsa:Address`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s <<payload_dev_47_provider_uid_hello>> as URI.
-`s12:Envelope/s12:Body/wsd:Hello/wsd:Scopes`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s <<payload_dev_47_discovery_scope>> as a list of URIs.
+`s12:Envelope/s12:Header/wsa:To`:: Optional. If present, this is the `wse:NotifyTo` address found in the subscription to <<vol1_spec_sdpi_p_actor_discovery_proxy>> events.
+`s12:Envelope/s12:Body/wsd:Hello/wsa:EndpointReference/wsa:Address`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s globally unique end-point reference.
+`s12:Envelope/s12:Body/wsd:Hello/wsd:Scopes`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s <<payload_dev_47_discovery_scope>>s as a list of URIs.
+`s12:Envelope/s12:Body/wsd:Hello/wsd:XAddrs`:: The <<term_transport_address>>, as a list of URIs, that may be used to communicate with the <<vol1_spec_sdpi_p_actor_somds_provider>>. All transport addresses should be included (e.g., IPv4, IPv6, etc).
+`s12:Envelope/s12:Body/wsd:Hello/wsd:MetadataVersion`:: A value, incremented by a positive integer, whenever there
+is a change in the metadata of the <<vol1_spec_sdpi_p_actor_somds_provider>> while the <<vol1_spec_sdpi_p_actor_somds_provider>> is operating. Unlike the `wsd:MetadataVersion` in <<ref_oasis_ws_discovery_2009>>, the `ws:MetadataVersion` may decrease when the <<vol1_spec_sdpi_p_actor_somds_provider>> or <<vol1_spec_sdpi_p_actor_discovery_proxy>> is restarted.
 
 :var_expected_actions_ref: <<vol2_clause_dev_47_message_hello>>
 include::../dev-a-default-expected-actions.adoc[]
@@ -50,6 +55,7 @@ include::../dev-a-default-expected-actions.adoc[]
 ===== {var_label_dev_47_message_bye} Message
 
 The <<vol2_clause_dev_47_message_bye, {var_label_dev_47_message_bye}>> message is encoded by using {var_uri_dpws_messaging}[DPWS Messaging].
+The message body sent to the consumer is encoded following the requirements for a unicast <<ref_oasis_ws_discovery_2009>> {var_label_dev_47_message_bye} message in managed mode to a <<vol1_spec_sdpi_p_actor_discovery_proxy>> (i.e., as if the <<vol1_spec_sdpi_p_actor_somds_consumer>> received the absence information directly from the <<vol1_spec_sdpi_p_actor_somds_provider>>).
 
 ====== Referenced Standards
 
@@ -69,7 +75,8 @@ include::../dev-a-default-trigger-events.adoc[]
 
 ====== Message Semantics
 
-`s12:Envelope/s12:Body/wsd:Bye/wsa:EndpointReference/wsa:Address`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s <<payload_dev_47_provider_uid_bye>> as URI.
+`s12:Envelope/s12:Header/wsa:To`:: If present, this address should be the `wse:NotifyTo` address found in the subscription message.
+`s12:Envelope/s12:Body/wsd:Bye/wsa:EndpointReference/wsa:Address`:: The <<vol1_spec_sdpi_p_actor_somds_provider>>'s globally unique end-point reference.
 
 :var_expected_actions_ref: <<vol2_clause_dev_47_message_bye>>
 include::../dev-a-default-expected-actions.adoc[]

--- a/asciidoc/volume2/dev-47/tf2-dev-47.adoc
+++ b/asciidoc/volume2/dev-47/tf2-dev-47.adoc
@@ -60,10 +60,13 @@ include::../../plantuml/vol2-figure-dev-47-sequence.puml[]
 <<acronym_biceps>> specifies an implicit discovery protocol for allowing <<vol1_spec_sdpi_p_actor_somds_consumer>>s to receive a notification when a <<vol1_spec_sdpi_p_actor_somds_provider>> is ready to exchange messages with other <<vol1_spec_sdpi_p_actor_somds_consumer>>s.
 If a <<vol1_spec_sdpi_p_actor_somds_consumer>> uses a <<vol1_spec_sdpi_p_actor_discovery_proxy>>, network presence is announced to the <<vol1_spec_sdpi_p_actor_somds_consumer>> by using the _{var_label_dev_47_message_hello}_ message of this transaction.
 
+Note that the {var_label_dev_47_message_hello} message described in this clause is a generic/abstract concept that can be implemented differently.
+It should not be confused with actual transport message specifications like, for example, the Hello message as described in <<vol2_clause_appendix_a_mdpws_dev_47_hello>>.
+
 [#vol2_clause_dev_47_message_hello_trigger_events]
 ====== Trigger Events
 
-If a <<vol1_spec_sdpi_p_actor_discovery_proxy>> is known to the <<vol1_spec_sdpi_p_actor_somds_consumer>> and the <<vol1_spec_sdpi_p_actor_somds_consumer>> is interested in {var_label_dev_47_message_hello} messages, this message is sent
+If a <<vol1_spec_sdpi_p_actor_discovery_proxy>> is known to the <<vol1_spec_sdpi_p_actor_somds_consumer>> and the <<vol1_spec_sdpi_p_actor_somds_consumer>> is interested in {var_label_dev_47_message_hello} messages, this message is sent:
 
 1. whenever a <<vol1_spec_sdpi_p_actor_somds_provider>> known to the <<vol1_spec_sdpi_p_actor_discovery_proxy>> joins an <<acronym_md_lan>>,
 2. when a <<vol1_spec_sdpi_p_actor_somds_provider>> known to the <<vol1_spec_sdpi_p_actor_discovery_proxy>> returns to normal _on-line_ operation after having indicated temporary suspension of message exchanges, or


### PR DESCRIPTION
## 📑 Description

Clarifies the use of `wsa:To` in greeting {`Hello`, `Bye`} notifications sent by a discovery proxy to a consumer. 

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
