### PR TITLE
Updated TLS version narrative for consistency with R1544.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Each section shall contain a list of action items of the following format: `<bri
 ### Added
 
 - Clarification on SDPi-P safety requirements and considerations to explicitly include the application of the IEEE 11073-10700 standard ([#529](https://github.com/IHE/DEV.SDPi/issues/529))
-- Updated TLS version narrative for consistency with R1544 ([#539](https://github.com/IHE/DEV.SDPi/pull/539)).
+- Updated TLS version narrative for consistency with R1544 ([#497](https://github.com/IHE/DEV.SDPi/issues/497)).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Each section shall contain a list of action items of the following format: `<bri
 ### Added
 
 - Clarification on SDPi-P safety requirements and considerations to explicitly include the application of the IEEE 11073-10700 standard ([#529](https://github.com/IHE/DEV.SDPi/issues/529))
+- Updated TLS version narrative for consistency with R1544 ([#539](https://github.com/IHE/DEV.SDPi/pull/539)).
 
 ### Changes
 

--- a/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
+++ b/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
@@ -1134,11 +1134,11 @@ Security is foundational for all interactions between <<vol1_spec_sdpi_p_actor_s
 Specific security technologies may vary based on jurisdictional requirements, regulations and the implementation technology, and will be detailed in the appropriate TF-2 technology specifications.
 All transactions indicate whether they require secure or unsecured connections.
 
-For the default <<acronym_sdpi_p>> connectivity technology, namely IEEE 11073 <<term_service_oriented_device_connectivity>>, TLS 1.2 (or higher versions) support is required (See <<ref_ieee_11073_20701_2018>> and <<ref_ieee_11073_20702_2016>>).
+For the default <<acronym_sdpi_p>> connectivity technology, namely IEEE 11073 <<term_service_oriented_device_connectivity>>, TLS 1.3 (or higher versions) support is required (See <<ref_ieee_11073_20701_2018>> and <<ref_ieee_11073_20702_2016>>).
 
 NOTE: The SDC standard <<ref_ieee_11073_20701_2018>> includes requirement R0064 stating that an SDC PARTICIPANT SHOULD utilize the highest TLS version. Herewith "the highest" is interpreted as the highest TLS version available, and not as the highest version negotiated between two SDC PARTICIPANTS.
 
-NOTE: TLS 1.2 is not sufficient for all types of connectivity (e.g., cloud, remote programming, etc.), and it has reported cipher suite weaknesses. TLS 1.3 (or higher, in the future) may be hence required depending on the risk associated with the device.
+NOTE: TLS 1.2 is not sufficient for all types of connectivity (e.g., cloud, remote programming, etc.), and it has reported cipher suite weaknesses. Therefore at least TLS 1.3 is required for <<acronym_sdpi_p>> connectivity. Higher versions may be required, in the future, depending on the risk associated with the device.
 
 .R1544
 [sdpi_requirement#r1544,sdpi_req_level=should]

--- a/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
+++ b/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
@@ -1134,7 +1134,7 @@ Security is foundational for all interactions between <<vol1_spec_sdpi_p_actor_s
 Specific security technologies may vary based on jurisdictional requirements, regulations and the implementation technology, and will be detailed in the appropriate TF-2 technology specifications.
 All transactions indicate whether they require secure or unsecured connections.
 
-For the default <<acronym_sdpi_p>> connectivity technology (that is <<term_service_oriented_device_connectivity>>,  <<ref_ieee_11073_20702_2016>>), <<ref_ieee_11073_20701_2018>> requires at least TLS version 1.2 (requirement R0063) and recommends <<vol1_spec_sdpi_p_actor_somds_participant>>s use the highest TLS version (requirement R0064).
+<<ref_ieee_11073_20701_2018>> requires at least TLS version 1.2 (requirement R0063) and recommends <<vol1_spec_sdpi_p_actor_somds_participant>>s use the highest TLS version (requirement R0064).
 
 NOTE: This requirement clarifies that "SDC PARTICIPANT SHOULD utilize the highest TLS version" means the highest TLS version widely available, and not the highest version negotiated between two SDC PARTICIPANTS.
 

--- a/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
+++ b/asciidoc/volume1/tf1-ch-10-sdpi-p.adoc
@@ -1134,11 +1134,11 @@ Security is foundational for all interactions between <<vol1_spec_sdpi_p_actor_s
 Specific security technologies may vary based on jurisdictional requirements, regulations and the implementation technology, and will be detailed in the appropriate TF-2 technology specifications.
 All transactions indicate whether they require secure or unsecured connections.
 
-For the default <<acronym_sdpi_p>> connectivity technology, namely IEEE 11073 <<term_service_oriented_device_connectivity>>, TLS 1.3 (or higher versions) support is required (See <<ref_ieee_11073_20701_2018>> and <<ref_ieee_11073_20702_2016>>).
+For the default <<acronym_sdpi_p>> connectivity technology (that is <<term_service_oriented_device_connectivity>>,  <<ref_ieee_11073_20702_2016>>), <<ref_ieee_11073_20701_2018>> requires at least TLS version 1.2 (requirement R0063) and recommends <<vol1_spec_sdpi_p_actor_somds_participant>>s use the highest TLS version (requirement R0064).
 
-NOTE: The SDC standard <<ref_ieee_11073_20701_2018>> includes requirement R0064 stating that an SDC PARTICIPANT SHOULD utilize the highest TLS version. Herewith "the highest" is interpreted as the highest TLS version available, and not as the highest version negotiated between two SDC PARTICIPANTS.
+NOTE: This requirement clarifies that "SDC PARTICIPANT SHOULD utilize the highest TLS version" means the highest TLS version widely available, and not the highest version negotiated between two SDC PARTICIPANTS.
 
-NOTE: TLS 1.2 is not sufficient for all types of connectivity (e.g., cloud, remote programming, etc.), and it has reported cipher suite weaknesses. Therefore at least TLS 1.3 is required for <<acronym_sdpi_p>> connectivity. Higher versions may be required, in the future, depending on the risk associated with the device.
+NOTE: TLS 1.2 is not sufficient for all types of connectivity (e.g., cloud, remote programming, etc.), and has reported cipher suite weaknesses (e.g., [CVE-2025-11419](https://nvd.nist.gov/vuln/detail/cve-2025-11419)). In the future, and in jurisdictions with additional security requirements, higher versions _may be required_, including TLS 1.3 and not only recommended. 
 
 .R1544
 [sdpi_requirement#r1544,sdpi_req_level=should]


### PR DESCRIPTION
## 📑 Description

Narrative (second paragraph in §1:10.5.4) says "TLS 1.2 (or higher versions)...", while R1544 demands version 1.3. Updated narrative to reference TLS v1.3 for consistency with requirement. 

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
