### PR TITLE
Clarify strictly increasing mdib version is scoped to subscription.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ Each section shall contain a list of action items of the following format: `<bri
 - Standalone SDPi Refactoring ([#499](https://github.com/IHE/DEV.SDPi/issues/499))
 - Fixed TimeStampVersion.xsd to resolve double nesting of sdpi:Epoch element ([#520](https://github.com/IHE/DEV.SDPi/issues/520))
 - Removed the DESCRIPTION EVENT SERVICE from list of minimum required services so consumers can determine the providers MdDescription can not change ([PR#532](https://github.com/IHE/DEV.SDPi/pull/532))
- 
+- Clarify strictly increasing mdib version is scoped to subscription ([#297](https://github.com/IHE/DEV.SDPi/issues/297)).
+
 ### Editorial Fixes
 
 - Corrected wording in the SES section template ([#530](https://github.com/IHE/DEV.SDPi/issues/530))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,14 @@ Each section shall contain a list of action items of the following format: `<bri
 ### Added
 
 - Clarification on SDPi-P safety requirements and considerations to explicitly include the application of the IEEE 11073-10700 standard ([#529](https://github.com/IHE/DEV.SDPi/issues/529))
-- Updated TLS version narrative for consistency with R1544 ([#497](https://github.com/IHE/DEV.SDPi/issues/497)).
 
 ### Changes
 
 - Standalone SDPi Refactoring ([#499](https://github.com/IHE/DEV.SDPi/issues/499))
 - Fixed TimeStampVersion.xsd to resolve double nesting of sdpi:Epoch element ([#520](https://github.com/IHE/DEV.SDPi/issues/520))
 - Removed the DESCRIPTION EVENT SERVICE from list of minimum required services so consumers can determine the providers MdDescription can not change ([PR#532](https://github.com/IHE/DEV.SDPi/pull/532))
-- Clarify strictly increasing mdib version is scoped to subscription ([#297](https://github.com/IHE/DEV.SDPi/issues/297)).
+- Reworded R1007 to clarify that strictly increasing mdib version is scoped to a subscription ([#297](https://github.com/IHE/DEV.SDPi/issues/297)).
+- Updated TLS version narrative for consistency with R1544 ([#497](https://github.com/IHE/DEV.SDPi/issues/497))
 
 ### Editorial Fixes
 

--- a/asciidoc/volume3/mdib-report-retrofit/tf3-ch-8.3.2.9-mdib-report-retrofit.adoc
+++ b/asciidoc/volume3/mdib-report-retrofit/tf3-ch-8.3.2.9-mdib-report-retrofit.adoc
@@ -28,7 +28,7 @@ BICEPS does not specify the order in which report messages are sent to <<vol1_sp
 ****
 [NORMATIVE]
 ====
-Within an <<acronym_mdib>> sequence, a <<vol1_spec_sdpi_p_actor_somds_provider>> shall send msg:WaveformStream, msg:EpisodicMetricReport, msg:EpisodicOperationalStateReport, msg:EpisodicComponentReport, msg:EpisodicAlertReport, msg:ObservedValueStream, msg:DescriptionModificationReport, and msg:EpisodicContextReport messages with a strictly increasing msg:AbstractReport/@MdibVersion.
+Within an <<acronym_mdib>> sequence and subscription, a <<vol1_spec_sdpi_p_actor_somds_provider>> shall send msg:WaveformStream, msg:EpisodicMetricReport, msg:EpisodicOperationalStateReport, msg:EpisodicComponentReport, msg:EpisodicAlertReport, msg:ObservedValueStream, msg:DescriptionModificationReport, and msg:EpisodicContextReport messages with a strictly increasing msg:AbstractReport/@MdibVersion.
 ====
 
 [NOTE]


### PR DESCRIPTION
## 📑 Description

Minor tweak to language on R1007 to clarify that strictly increasing mdib versions are scoped to subscription as well. 

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
