### PR TITLE
511 add semantic support for deprecated requirements and oids

### DIFF
--- a/.ci/asciidoc-converter/build.gradle.kts
+++ b/.ci/asciidoc-converter/build.gradle.kts
@@ -68,6 +68,10 @@ kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_17
     }
+    sourceSets.all {
+        // Must be explicitly enabled!
+        languageSettings.enableLanguageFeature("ExplicitBackingFields")
+    }
 }
 
 application {

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/AsciidocConverter.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/AsciidocConverter.kt
@@ -74,6 +74,8 @@ class AsciidocConverter(
     private val profileContentModuleCollector = ContentModuleIncludeProcessor()
     private val profileUseCaseSupportCollector = SupportUseCaseIncludeProcessor()
     private val externalStandardsProcessor = ExternalStandardProcessor()
+    private val deprecatedRequirementsProcessor = DeprecateRequirementProcessor()
+
 
     val infoCollector = SdpiInformationCollector(
         bibliographyCollector,
@@ -81,7 +83,8 @@ class AsciidocConverter(
         profileTransactionCollector,
         profileUseCaseSupportCollector,
         profileContentModuleCollector,
-        externalStandardsProcessor
+        externalStandardsProcessor,
+        deprecatedRequirementsProcessor
     )
 
     override fun run() {
@@ -120,6 +123,8 @@ class AsciidocConverter(
         asciidoctor.javaExtensionRegistry().blockMacro(profileUseCaseSupportCollector)
 
         asciidoctor.javaExtensionRegistry().blockMacro(profileContentModuleCollector)
+
+        asciidoctor.javaExtensionRegistry().blockMacro(deprecatedRequirementsProcessor)
 
         // Gather SDPI specific information from the document such as
         // requirements and use-cases.
@@ -208,6 +213,11 @@ class AsciidocConverter(
             writeArtifact(
                 "sdpi-requirements",
                 jsonFormatter.encodeToString(infoCollector.requirements().values)
+            )
+
+            writeArtifact(
+                "sdpi-requirements-deprecated",
+                jsonFormatter.encodeToString(deprecatedRequirementsProcessor.requirements().values)
             )
         }
 

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/AsciidocConverter.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/AsciidocConverter.kt
@@ -222,20 +222,20 @@ class AsciidocConverter(
 
             writeArtifact(
                 "sdpi-requirements-deprecated",
-                jsonFormatter.encodeToString(deprecatedRequirementsProcessor.entries().values)
+                jsonFormatter.encodeToString(deprecatedRequirementsProcessor.entries.values)
             )
 
             writeArtifact(
                 "sdpi-transactions-deprecated",
-                jsonFormatter.encodeToString(deprecatedTransactionsProcessor.entries().values)
+                jsonFormatter.encodeToString(deprecatedTransactionsProcessor.entries.values)
             )
 
             writeArtifact(
                 "sdpi-deprecated",
                 jsonFormatter.encodeToString(
-                    deprecatedOidProcessor.entries().values
-                + deprecatedRequirementsProcessor.entries().values
-                + deprecatedTransactionsProcessor.entries().values)
+                    deprecatedOidProcessor.entries.values
+                + deprecatedRequirementsProcessor.entries.values
+                + deprecatedTransactionsProcessor.entries.values)
             )
         }
 

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/AsciidocConverter.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/AsciidocConverter.kt
@@ -76,7 +76,7 @@ class AsciidocConverter(
     private val externalStandardsProcessor = ExternalStandardProcessor()
     private val deprecatedRequirementsProcessor = DeprecateRequirementProcessor()
     private val deprecatedTransactionsProcessor = DeprecateTransactionProcessor()
-
+    private val deprecatedOidProcessor = DeprecateProcessor()
 
     val infoCollector = SdpiInformationCollector(
         bibliographyCollector,
@@ -86,7 +86,8 @@ class AsciidocConverter(
         profileContentModuleCollector,
         externalStandardsProcessor,
         deprecatedRequirementsProcessor,
-        deprecatedTransactionsProcessor
+        deprecatedTransactionsProcessor,
+        deprecatedOidProcessor
     )
 
     override fun run() {
@@ -126,6 +127,7 @@ class AsciidocConverter(
 
         asciidoctor.javaExtensionRegistry().blockMacro(profileContentModuleCollector)
 
+        asciidoctor.javaExtensionRegistry().blockMacro(deprecatedOidProcessor)
         asciidoctor.javaExtensionRegistry().blockMacro(deprecatedRequirementsProcessor)
         asciidoctor.javaExtensionRegistry().blockMacro(deprecatedTransactionsProcessor)
 
@@ -226,6 +228,14 @@ class AsciidocConverter(
             writeArtifact(
                 "sdpi-transactions-deprecated",
                 jsonFormatter.encodeToString(deprecatedTransactionsProcessor.entries().values)
+            )
+
+            writeArtifact(
+                "sdpi-deprecated",
+                jsonFormatter.encodeToString(
+                    deprecatedOidProcessor.entries().values
+                + deprecatedRequirementsProcessor.entries().values
+                + deprecatedTransactionsProcessor.entries().values)
             )
         }
 

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/AsciidocConverter.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/AsciidocConverter.kt
@@ -75,6 +75,7 @@ class AsciidocConverter(
     private val profileUseCaseSupportCollector = SupportUseCaseIncludeProcessor()
     private val externalStandardsProcessor = ExternalStandardProcessor()
     private val deprecatedRequirementsProcessor = DeprecateRequirementProcessor()
+    private val deprecatedTransactionsProcessor = DeprecateTransactionProcessor()
 
 
     val infoCollector = SdpiInformationCollector(
@@ -84,7 +85,8 @@ class AsciidocConverter(
         profileUseCaseSupportCollector,
         profileContentModuleCollector,
         externalStandardsProcessor,
-        deprecatedRequirementsProcessor
+        deprecatedRequirementsProcessor,
+        deprecatedTransactionsProcessor
     )
 
     override fun run() {
@@ -125,6 +127,7 @@ class AsciidocConverter(
         asciidoctor.javaExtensionRegistry().blockMacro(profileContentModuleCollector)
 
         asciidoctor.javaExtensionRegistry().blockMacro(deprecatedRequirementsProcessor)
+        asciidoctor.javaExtensionRegistry().blockMacro(deprecatedTransactionsProcessor)
 
         // Gather SDPI specific information from the document such as
         // requirements and use-cases.
@@ -217,7 +220,12 @@ class AsciidocConverter(
 
             writeArtifact(
                 "sdpi-requirements-deprecated",
-                jsonFormatter.encodeToString(deprecatedRequirementsProcessor.requirements().values)
+                jsonFormatter.encodeToString(deprecatedRequirementsProcessor.entries().values)
+            )
+
+            writeArtifact(
+                "sdpi-transactions-deprecated",
+                jsonFormatter.encodeToString(deprecatedTransactionsProcessor.entries().values)
             )
         }
 

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/BlockAttribute.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/BlockAttribute.kt
@@ -23,6 +23,14 @@ enum class BlockAttribute(val key: String) {
 }
 
 /**
+ * Attributes for deprecation inline block macros.
+ */
+enum class DeprecationAttributes(val key: String) {
+    // The version when a requirement, transaction, &c became deprecated.
+    VERSION("version"),
+}
+
+/**
  * Defines attribute keywords for sdpi_requirement blocks
  */
 sealed class RequirementAttributes {

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/Util.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/Util.kt
@@ -3,7 +3,6 @@ package org.sdpi.asciidoc
 import org.apache.logging.log4j.kotlin.loggerOf
 import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.ast.StructuralNode
-import org.jruby.util.ResourceException.InvalidArguments
 import org.sdpi.asciidoc.extension.Roles
 import org.sdpi.asciidoc.model.BlockOwner
 import org.sdpi.asciidoc.model.RequirementLevel
@@ -155,7 +154,7 @@ fun getTitleFrom(block: StructuralNode): String {
 
 fun makeLink(strAnchor: String, strText: String, strClass: String? = null): String {
     if (strAnchor.contains(" ")) {
-        throw  InvalidArguments("Anchor '$strAnchor' contains spaces")
+        throw IllegalArgumentException("Anchor '$strAnchor' contains spaces")
     }
 
     return if (strClass == null) {

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/DeprecationProcessors.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/DeprecationProcessors.kt
@@ -10,6 +10,7 @@ import org.sdpi.asciidoc.model.DeprecatedOid
 import org.sdpi.asciidoc.model.WellKnownOid
 import org.sdpi.asciidoc.model.makeConformityVersionOid
 
+const val BLOCK_MACRO_NAME_DEPRECATE = "Deprecate"
 const val BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT = "DeprecateRequirement"
 const val BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION = "DeprecateTransaction"
 
@@ -48,6 +49,58 @@ class DeprecateRequirementProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRE
         return null
     }
 }
+@Name(BLOCK_MACRO_NAME_DEPRECATE)
+class DeprecateProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE) {
+    private companion object : Logging
+
+    private val entries = mutableMapOf<String, DeprecatedOid>()
+
+    fun entries() : Map<String, DeprecatedOid> {
+        return entries
+    }
+
+    fun isDeprecated(strOid: String) : DeprecatedOid? {
+        return entries[strOid]
+    }
+
+    override fun process(parent: StructuralNode, strTarget: String, attributes: MutableMap<String, Any>): Any? {
+
+        val strVersion = attributes[DeprecationAttributes.VERSION.key]?.toString()
+        checkNotNull(strVersion) {
+            "$BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT missing required attribute '${DeprecationAttributes.VERSION.key}'".also {
+                logger.error{it}
+            }
+        }
+        println("**Deprecating $strTarget")
+        val strVersionOid = makeConformityVersionOid(strVersion)
+
+
+        check(strTarget.startsWith(WellKnownOid.DEV_SDPi.oid)) {
+            "Oid `$strTarget` must begin with ${WellKnownOid.DEV_SDPi.oid}".also {
+                logger.error{it}
+            }
+        }
+
+        val reOid = Regex("""^(?:(?:[01]\.(?:[0-9]|[1-3][0-9]))|(?:2\.(?:0|[1-9]\d*)))(?:\.(?:0|[1-9]\d*))*$""")
+        check(reOid.matches(strTarget)) {
+            "Oid `$strTarget` must be a valid oid".also {
+                logger.error{it}
+            }
+        }
+
+        checkNotNull(!entries.containsKey(strTarget)) {
+            "Oid $strTarget is already marked deprecated".also {
+                logger.error{it}
+            }
+        }
+
+
+        entries[strTarget] = DeprecatedOid(strTarget, strVersionOid)
+
+        return null
+    }
+}
+
 @Name(BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION)
 class DeprecateTransactionProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION) {
     private companion object : Logging
@@ -66,7 +119,9 @@ class DeprecateTransactionProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRE
 
         val strVersion = attributes[DeprecationAttributes.VERSION.key]?.toString()
         checkNotNull(strVersion) {
-            logger.error("$BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION missing required attribute '${DeprecationAttributes.VERSION.key}'")
+            "$BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION missing required attribute '${DeprecationAttributes.VERSION.key}'".also {
+                logger.error{it}
+            }
         }
 
         val strVersionOid = makeConformityVersionOid(strVersion)
@@ -74,7 +129,9 @@ class DeprecateTransactionProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRE
         val strTransactionId = getTransactionOid(strTarget)
 
         checkNotNull(!entries.containsKey(strTransactionId)) {
-            logger.error("Transaction $strTransactionId is already marked deprecated")
+            "Transaction $strTransactionId is already marked deprecated".also {
+                logger.error{it}
+            }
         }
 
         entries[strTransactionId] = DeprecatedOid(strTransactionId, strVersionOid)

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/DeprecationProcessors.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/DeprecationProcessors.kt
@@ -4,7 +4,6 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.extension.BlockMacroProcessor
 import org.asciidoctor.extension.Name
-import org.jruby.util.ResourceException.InvalidArguments
 import org.sdpi.asciidoc.DeprecationAttributes
 import org.sdpi.asciidoc.model.DeprecatedOid
 import org.sdpi.asciidoc.model.WellKnownOid
@@ -18,11 +17,8 @@ const val BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION = "DeprecateTransaction"
 class DeprecateRequirementProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT) {
     private companion object : Logging
 
-    private val entries = mutableMapOf<String, DeprecatedOid>()
-
-    fun entries() : Map<String, DeprecatedOid> {
-        return entries
-    }
+    val entries: Map<String, DeprecatedOid>
+        field = mutableMapOf()
 
     fun isDeprecated(strRequirementOid: String) : DeprecatedOid? {
         return entries[strRequirementOid]
@@ -37,7 +33,7 @@ class DeprecateRequirementProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRE
 
         val strVersionOid = makeConformityVersionOid(strVersion)
 
-        val requirementNumber: Int = parseRequirementNumber(strTarget)
+        val requirementNumber = parseRequirementNumber(strTarget)
         val strRequirementId = getRequirementOid(requirementNumber)
 
         checkNotNull(!entries.containsKey(strRequirementId)) {
@@ -53,11 +49,8 @@ class DeprecateRequirementProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRE
 class DeprecateProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE) {
     private companion object : Logging
 
-    private val entries = mutableMapOf<String, DeprecatedOid>()
-
-    fun entries() : Map<String, DeprecatedOid> {
-        return entries
-    }
+    val entries: Map<String, DeprecatedOid>
+        field = mutableMapOf()
 
     fun isDeprecated(strOid: String) : DeprecatedOid? {
         return entries[strOid]
@@ -105,11 +98,8 @@ class DeprecateProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE) {
 class DeprecateTransactionProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION) {
     private companion object : Logging
 
-    private val entries = mutableMapOf<String, DeprecatedOid>()
-
-    fun entries() : Map<String, DeprecatedOid> {
-        return entries
-    }
+    val entries: Map<String, DeprecatedOid>
+        field = mutableMapOf()
 
     fun isDeprecated(strTransactionOid: String) : DeprecatedOid? {
         return entries[strTransactionOid]
@@ -146,6 +136,6 @@ class DeprecateTransactionProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRE
                 return "${WellKnownOid.DEV_TRANSACTION.oid}.$strLeaf"
             }
         }
-        throw InvalidArguments("'$strTransactionId' is not a valid transaction id")
+        throw IllegalArgumentException("'$strTransactionId' is not a valid transaction id")
     }
 }

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/DeprecationProcessors.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/DeprecationProcessors.kt
@@ -4,11 +4,14 @@ import org.apache.logging.log4j.kotlin.Logging
 import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.extension.BlockMacroProcessor
 import org.asciidoctor.extension.Name
+import org.jruby.util.ResourceException.InvalidArguments
 import org.sdpi.asciidoc.DeprecationAttributes
 import org.sdpi.asciidoc.model.DeprecatedOid
+import org.sdpi.asciidoc.model.WellKnownOid
 import org.sdpi.asciidoc.model.makeConformityVersionOid
 
 const val BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT = "DeprecateRequirement"
+const val BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION = "DeprecateTransaction"
 
 @Name(BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT)
 class DeprecateRequirementProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT) {
@@ -16,7 +19,7 @@ class DeprecateRequirementProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRE
 
     private val entries = mutableMapOf<String, DeprecatedOid>()
 
-    fun requirements() : Map<String, DeprecatedOid> {
+    fun entries() : Map<String, DeprecatedOid> {
         return entries
     }
 
@@ -43,5 +46,49 @@ class DeprecateRequirementProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRE
         entries[strRequirementId] = DeprecatedOid(strRequirementId, strVersionOid)
 
         return null
+    }
+}
+@Name(BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION)
+class DeprecateTransactionProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION) {
+    private companion object : Logging
+
+    private val entries = mutableMapOf<String, DeprecatedOid>()
+
+    fun entries() : Map<String, DeprecatedOid> {
+        return entries
+    }
+
+    fun isDeprecated(strTransactionOid: String) : DeprecatedOid? {
+        return entries[strTransactionOid]
+    }
+
+    override fun process(parent: StructuralNode, strTarget: String, attributes: MutableMap<String, Any>): Any? {
+
+        val strVersion = attributes[DeprecationAttributes.VERSION.key]?.toString()
+        checkNotNull(strVersion) {
+            logger.error("$BLOCK_MACRO_NAME_DEPRECATE_TRANSACTION missing required attribute '${DeprecationAttributes.VERSION.key}'")
+        }
+
+        val strVersionOid = makeConformityVersionOid(strVersion)
+
+        val strTransactionId = getTransactionOid(strTarget)
+
+        checkNotNull(!entries.containsKey(strTransactionId)) {
+            logger.error("Transaction $strTransactionId is already marked deprecated")
+        }
+
+        entries[strTransactionId] = DeprecatedOid(strTransactionId, strVersionOid)
+
+        return null
+    }
+
+    private fun getTransactionOid(strTransactionId: String): String {
+        if (strTransactionId.startsWith("DEV-")) {
+            val strLeaf = strTransactionId.substring(4)
+            if (strLeaf.toIntOrNull() != null) {
+                return "${WellKnownOid.DEV_TRANSACTION.oid}.$strLeaf"
+            }
+        }
+        throw InvalidArguments("'$strTransactionId' is not a valid transaction id")
     }
 }

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/DeprecationProcessors.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/DeprecationProcessors.kt
@@ -1,0 +1,47 @@
+package org.sdpi.asciidoc.extension
+
+import org.apache.logging.log4j.kotlin.Logging
+import org.asciidoctor.ast.StructuralNode
+import org.asciidoctor.extension.BlockMacroProcessor
+import org.asciidoctor.extension.Name
+import org.sdpi.asciidoc.DeprecationAttributes
+import org.sdpi.asciidoc.model.DeprecatedOid
+import org.sdpi.asciidoc.model.makeConformityVersionOid
+
+const val BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT = "DeprecateRequirement"
+
+@Name(BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT)
+class DeprecateRequirementProcessor : BlockMacroProcessor(BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT) {
+    private companion object : Logging
+
+    private val entries = mutableMapOf<String, DeprecatedOid>()
+
+    fun requirements() : Map<String, DeprecatedOid> {
+        return entries
+    }
+
+    fun isDeprecated(strRequirementOid: String) : DeprecatedOid? {
+        return entries[strRequirementOid]
+    }
+
+    override fun process(parent: StructuralNode, strTarget: String, attributes: MutableMap<String, Any>): Any? {
+
+        val strVersion = attributes[DeprecationAttributes.VERSION.key]?.toString()
+        checkNotNull(strVersion) {
+            logger.error("$BLOCK_MACRO_NAME_DEPRECATE_REQUIREMENT missing required attribute '${DeprecationAttributes.VERSION.key}'")
+        }
+
+        val strVersionOid = makeConformityVersionOid(strVersion)
+
+        val requirementNumber: Int = parseRequirementNumber(strTarget)
+        val strRequirementId = getRequirementOid(requirementNumber)
+
+        checkNotNull(!entries.containsKey(strRequirementId)) {
+            logger.error("Requirement $strRequirementId is already marked deprecated")
+        }
+
+        entries[strRequirementId] = DeprecatedOid(strRequirementId, strVersionOid)
+
+        return null
+    }
+}

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/RequirementBlockProcessor2.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/RequirementBlockProcessor2.kt
@@ -8,6 +8,7 @@ import org.asciidoctor.extension.BlockProcessor
 import org.asciidoctor.extension.Contexts
 import org.asciidoctor.extension.Name
 import org.asciidoctor.extension.Reader
+import org.jruby.util.ResourceException.InvalidArguments
 import org.sdpi.asciidoc.*
 import org.sdpi.asciidoc.model.WellKnownOid
 import java.util.*
@@ -69,7 +70,7 @@ class RequirementBlockProcessor2 : BlockProcessor(BLOCK_NAME_SDPI_REQUIREMENT) {
 
     override fun process(parent: StructuralNode, reader: Reader, attributes: MutableMap<String, Any>): Any {
         val requirementNumber: Int = getRequirementNumber(attributes)
-        val strGlobalId = getRequirementOid(parent, requirementNumber, attributes)
+        val strGlobalId = getRequirementOid(requirementNumber)
         val strLinkId = String.format("r%04d", requirementNumber)
 
         logger.info("Found requirement #$requirementNumber at ${parent.sourceLocation}")
@@ -100,7 +101,6 @@ class RequirementBlockProcessor2 : BlockProcessor(BLOCK_NAME_SDPI_REQUIREMENT) {
         )
     }
 
-
     /**
      * Retrieve the requirement number from available attributes.
      * The requirement number must be specified as a title and the id.
@@ -128,23 +128,6 @@ class RequirementBlockProcessor2 : BlockProcessor(BLOCK_NAME_SDPI_REQUIREMENT) {
     }
 
     /**
-     * Retrieve the globally unique object id for the requirement.
-     * See Assigning Unique Identifiers [[SDPi:§1:A.4.2.1]]
-     *
-     */
-    private fun getRequirementOid(
-        parent: StructuralNode,
-        requirementNumber: Int,
-        mutableAttributes: MutableMap<String, Any>
-    ): String {
-        val strParent = WellKnownOid.DEV_REQUIREMENT.oid
-
-        // Global unique ids are composed of the source specification's oid,
-        // ".2." + the requirement number. [[SDPi:§1:A.4.2.1]]
-        return "$strParent.$requirementNumber"
-    }
-
-    /**
      * Creates text for the requirement title in the document
      */
     private fun formatRequirementTitle(requirementNumber: Int, strGlobalId: String): String {
@@ -154,4 +137,29 @@ class RequirementBlockProcessor2 : BlockProcessor(BLOCK_NAME_SDPI_REQUIREMENT) {
             return "R${String.format("%04d", requirementNumber)} [.global-id]#`(${strGlobalId})`#"
         }
     }
+}
+
+
+
+fun parseRequirementNumber(strRequirement: String) : Int {
+    val requirementNumberFormat = "^[rR](\\d+)$".toRegex()
+
+    val nRequirementNumber = requirementNumberFormat.findAll(strRequirement)
+        .map { it.groupValues[1] }.toList().first().toInt()
+    return nRequirementNumber
+}
+
+/**
+ * Retrieve the globally unique object id for the requirement.
+ * See Assigning Unique Identifiers [[SDPi:§1:A.4.2.1]]
+ *
+ */
+fun getRequirementOid(
+    requirementNumber: Int,
+): String {
+    val strParent = WellKnownOid.DEV_REQUIREMENT.oid
+
+    // Global unique ids are composed of the source specification's oid,
+    // ".2." + the requirement number. [[SDPi:§1:A.4.2.1]]
+    return "$strParent.$requirementNumber"
 }

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/RequirementBlockProcessor2.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/RequirementBlockProcessor2.kt
@@ -8,7 +8,6 @@ import org.asciidoctor.extension.BlockProcessor
 import org.asciidoctor.extension.Contexts
 import org.asciidoctor.extension.Name
 import org.asciidoctor.extension.Reader
-import org.jruby.util.ResourceException.InvalidArguments
 import org.sdpi.asciidoc.*
 import org.sdpi.asciidoc.model.WellKnownOid
 import java.util.*

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/SdpiInformationCollector.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/SdpiInformationCollector.kt
@@ -20,7 +20,8 @@ class SdpiInformationCollector(
     private val profileTransactions: TransactionIncludeProcessor,
     private val profileUseCases: SupportUseCaseIncludeProcessor,
     private val profileContentModuleReferences: ContentModuleIncludeProcessor,
-    private val externalStandardsProcessor : ExternalStandardProcessor
+    private val externalStandardsProcessor : ExternalStandardProcessor,
+    private val deprecatedRequirementsProcessor : DeprecateRequirementProcessor
 ) : Treeprocessor() {
     private companion object : Logging
 
@@ -1263,6 +1264,14 @@ class SdpiInformationCollector(
 
     private fun validateRequirements() {
         for (req in requirements.values) {
+            val deprecation = deprecatedRequirementsProcessor.isDeprecated(req.oid)
+            check(null == deprecation) {
+
+                "Requirement ${req.localId} was deprecated in specification version ${deprecation?.oidVersion}".also {
+                    logger.error { it }
+                }
+            }
+
             for (strActorId in req.actors()) {
                 val actor = actors[strActorId]
                 checkNotNull(actor) {

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/SdpiInformationCollector.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/SdpiInformationCollector.kt
@@ -22,7 +22,8 @@ class SdpiInformationCollector(
     private val profileContentModuleReferences: ContentModuleIncludeProcessor,
     private val externalStandardsProcessor : ExternalStandardProcessor,
     private val deprecatedRequirementsProcessor : DeprecateRequirementProcessor,
-    private val deprecatedTransactionsProcessor : DeprecateTransactionProcessor
+    private val deprecatedTransactionsProcessor : DeprecateTransactionProcessor,
+    private val decprecatedOidsProcessor: DeprecateProcessor
 ) : Treeprocessor() {
     private companion object : Logging
 
@@ -93,6 +94,10 @@ class SdpiInformationCollector(
         validateTransactions()
         validateRequirements()
         validateActors()
+
+        validateProfiles()
+        validateUseCases()
+        validateContentModules()
 
         validateObjectIds()
 
@@ -1220,7 +1225,17 @@ class SdpiInformationCollector(
         return blockOids
     }
 
+    private fun checkForDeprecatedOids(oids : List<String>, strContext : String) {
+        for(oid in oids) {
+            val deprecation = decprecatedOidsProcessor.isDeprecated(oid)
+            check(null == deprecation) {
 
+                "$strContext $oid was deprecated in specification version ${deprecation?.oidVersion}".also {
+                    logger.error { it }
+                }
+            }
+        }
+    }
     // endregion
 
     //region Validation
@@ -1254,6 +1269,7 @@ class SdpiInformationCollector(
         for (trans in transactions.values) {
             for(oid in trans.oids) {
                 val deprecation = deprecatedTransactionsProcessor.isDeprecated(oid)
+                    ?: decprecatedOidsProcessor.isDeprecated(oid)
                 check(null == deprecation) {
 
                     "Transaction $oid was deprecated in specification version ${deprecation?.oidVersion}".also {
@@ -1276,6 +1292,7 @@ class SdpiInformationCollector(
     private fun validateRequirements() {
         for (req in requirements.values) {
             val deprecation = deprecatedRequirementsProcessor.isDeprecated(req.oid)
+                ?: decprecatedOidsProcessor.isDeprecated(req.oid)
             check(null == deprecation) {
 
                 "Requirement ${req.localId} was deprecated in specification version ${deprecation?.oidVersion}".also {
@@ -1347,6 +1364,8 @@ class SdpiInformationCollector(
     private fun validateActors() {
         for(profile in profiles.values) {
             for(actor in profile.actorReferences()) {
+                checkForDeprecatedOids(actor.oids, "Actor")
+
                 if (actor.requiredActorGroupings != null) {
                     //println("***** Checking actor grouping for ${actor.id}")
                     for(grouping in actor.requiredActorGroupings) {
@@ -1432,4 +1451,25 @@ class SdpiInformationCollector(
 
     //endregion
 
+    //region General validation
+
+    private fun validateProfiles() {
+        for(profile in profiles.values) {
+            checkForDeprecatedOids(profile.oids, "Profile")
+        }
+    }
+
+    private fun validateUseCases() {
+        for(useCase in useCases.values) {
+            checkForDeprecatedOids(useCase.oids, "Use case")
+        }
+    }
+
+    private fun validateContentModules() {
+        for(module in contentModules.values) {
+            checkForDeprecatedOids(module.oids, "Content module")
+        }
+    }
+
+    //endregion
 }

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/SdpiInformationCollector.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/extension/SdpiInformationCollector.kt
@@ -21,7 +21,8 @@ class SdpiInformationCollector(
     private val profileUseCases: SupportUseCaseIncludeProcessor,
     private val profileContentModuleReferences: ContentModuleIncludeProcessor,
     private val externalStandardsProcessor : ExternalStandardProcessor,
-    private val deprecatedRequirementsProcessor : DeprecateRequirementProcessor
+    private val deprecatedRequirementsProcessor : DeprecateRequirementProcessor,
+    private val deprecatedTransactionsProcessor : DeprecateTransactionProcessor
 ) : Treeprocessor() {
     private companion object : Logging
 
@@ -1251,6 +1252,16 @@ class SdpiInformationCollector(
 
     private fun validateTransactions() {
         for (trans in transactions.values) {
+            for(oid in trans.oids) {
+                val deprecation = deprecatedTransactionsProcessor.isDeprecated(oid)
+                check(null == deprecation) {
+
+                    "Transaction $oid was deprecated in specification version ${deprecation?.oidVersion}".also {
+                        logger.error { it }
+                    }
+                }
+            }
+
             if (trans.actorRoles != null) {
                 for (role in trans.actorRoles) {
                     val actor = actors[role.actorId]

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/model/SdpiOidReference.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/model/SdpiOidReference.kt
@@ -1,6 +1,7 @@
 package org.sdpi.asciidoc.model
 
 import kotlinx.serialization.Serializable
+import org.jruby.util.ResourceException.InvalidArguments
 
 @Serializable
 data class SdpiOidReference(val root: WellKnownOid, val oid: String, val description: String, val anchor: String) :
@@ -23,6 +24,9 @@ data class SdpiOidReference(val root: WellKnownOid, val oid: String, val descrip
 
 }
 
+@Serializable
+data class DeprecatedOid(val oidDeprecated: String, val oidVersion: String)
+
 // Oids for well known things defined in the specification. See
 // Appendix 3.C Oid Identifiers in the specification for parent
 // oid definitions.
@@ -35,6 +39,13 @@ enum class WellKnownOid(val id: String, val oid: String, val typeLabel: String, 
         "1.3.6.1.4.1.19376.1.6.2.10",
         "SDPi",
         "Parent OID for the SDPi specification"
+    ),
+
+    DEV_CONFORMITY_VERSION(
+      id="conformity-version",
+      oid =DEV_SDPi.oid + ".0",
+      typeLabel = "Conformity version",
+      description = "Parent oid for specification versions"
     ),
 
     // Parent oid for all actors.
@@ -105,4 +116,13 @@ enum class WellKnownOid(val id: String, val oid: String, val typeLabel: String, 
 
 fun parseOidId(strId: String): WellKnownOid? {
     return WellKnownOid.entries.firstOrNull { it.id == strId }
+}
+
+fun makeConformityVersionOid(strSpecVersion: String): String {
+    val regex = Regex("""^\d+\.\d+\.\d+$""")
+    if (!regex.matches(strSpecVersion)) {
+        throw InvalidArguments("'$strSpecVersion' is not a valid specification version")
+    }
+
+    return WellKnownOid.DEV_CONFORMITY_VERSION.oid + "." + strSpecVersion
 }

--- a/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/model/SdpiOidReference.kt
+++ b/.ci/asciidoc-converter/src/main/kotlin/org/sdpi/asciidoc/model/SdpiOidReference.kt
@@ -1,7 +1,6 @@
 package org.sdpi.asciidoc.model
 
 import kotlinx.serialization.Serializable
-import org.jruby.util.ResourceException.InvalidArguments
 
 @Serializable
 data class SdpiOidReference(val root: WellKnownOid, val oid: String, val description: String, val anchor: String) :
@@ -121,7 +120,7 @@ fun parseOidId(strId: String): WellKnownOid? {
 fun makeConformityVersionOid(strSpecVersion: String): String {
     val regex = Regex("""^\d+\.\d+\.\d+$""")
     if (!regex.matches(strSpecVersion)) {
-        throw InvalidArguments("'$strSpecVersion' is not a valid specification version")
+        throw IllegalArgumentException("'$strSpecVersion' is not a valid specification version")
     }
 
     return WellKnownOid.DEV_CONFORMITY_VERSION.oid + "." + strSpecVersion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Each section shall contain a list of action items of the following format: `<bri
 - Clarification on SDPi-P safety requirements and considerations to explicitly include the application of the IEEE 11073-10700 standard ([#529](https://github.com/IHE/DEV.SDPi/issues/529))
 - Clarification on the use of `wsa:To` in greeting {`Hello`, `Bye`} notifications sent by a discovery proxy to a consumer ([#534](https://github.com/IHE/DEV.SDPi/issues/534))
 - Required SDPi-P actor grouping entries for BICEPS Content Creator and BICEPS Content Consumer in TF-1:10.3 ([#476](https://github.com/IHE/DEV.SDPi/issues/476))
+- Support semantic markup for deprecating requirements, transactions, use-cases, profiles, content modules and actors ([#511](https://github.com/IHE/DEV.SDPi/issues/511)).
 
 ### Changes
 

--- a/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -954,6 +954,29 @@ Only the leaf arc is required when the oid value begins with a `.`. The document
 
 Multiple oids may be associated with an item by separating them with commas, though generally all items have a single defining OID. 
 
+=== Deprecating object ids (oids)
+
+As the standard evolves objects, such as requirements and transactions, may become obsolete. However,
+once assigned, the meaning of OIDs should not change once assigned. 
+
+To ensure that some things that should not be forgotten are not lost, 
+`DeprecatedX` are [Asciidoc block macros](https://docs.asciidoctor.org/asciidoctorj/latest/extensions/block-macro-processor/) provide a mechanism to reserve obsolete identifiers, which have been removed
+from the source. The processor will report an error when deprecated object ids are re-used. 
+
+|===
+|Macro | Example | Description
+
+|`DeprecateRequirement` | `DeprecateRequirement::R1005[version="1.2.3"]` | Marks a requirement number, defined in the specification, as deprecated.
+
+|`DeprecateTransaction` | `DeprecateTransaction::DEV-23[version="1.2.3"]` | Marks a transaction, defined in the specification, as deprecated.
+
+|===
+
+NOTE: The `version` attribute is required. It gives the document version (see 
+[`sdpi-standard.adoc`](https://github.com/IHE/DEV.SDPi/blob/master/asciidoc/sdpi-standard.adoc))
+when the OID was first no longer available. Format is: 
+`<sdpi_version_major>.<sdpi_version_minor>.<sdpi_version_revision>`. 
+
 [[cross-referencing]]
 === Cross-referencing
 

--- a/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
+++ b/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc
@@ -970,12 +970,18 @@ from the source. The processor will report an error when deprecated object ids a
 
 |`DeprecateTransaction` | `DeprecateTransaction::DEV-23[version="1.2.3"]` | Marks a transaction, defined in the specification, as deprecated.
 
+|`Deprecate` | `Deprecate::1.3.6.1.4.1.19376.1.6.2.10.3.26[version="1.2.3"]` | Marks an actor, use-case, profile or content module, defined in the specification, as deprecated.
+
 |===
 
 NOTE: The `version` attribute is required. It gives the document version (see 
 [`sdpi-standard.adoc`](https://github.com/IHE/DEV.SDPi/blob/master/asciidoc/sdpi-standard.adoc))
 when the OID was first no longer available. Format is: 
 `<sdpi_version_major>.<sdpi_version_minor>.<sdpi_version_revision>`. 
+
+Deprecated requirements and transactions are exported to `sdpi-requirements-deprecated.json` and
+`sdpi-transactions-deprecated.json`, respectively. All deprecated oids (including transactions and
+requirements) are exported to `sdpi-deprecated.json` for reference. 
 
 [[cross-referencing]]
 === Cross-referencing


### PR DESCRIPTION
## 📑 Description

Added 3 new block macros to support deprecating requirements, transactions, actors, profiles, content modules and use-cases. 

See [Deprecating object ids (oids)](https://github.com/IHE/DEV.SDPi/blob/511-add-semantic-support-for-deprecated-requirements-and-oids/articles/sdpi-article-ihe-tf-asciidoc-cookbook.adoc#deprecating-object-ids-oids)

For example:

```
// Requirement
DeprecateRequirement::R0063[version="1.2.3"]

// Transaction
DeprecateTransaction::DEV-99[version="2.1.2"]

// actor
Deprecate::1.3.6.1.4.1.19376.1.6.2.10.3.26[version="1.1.2"]
 
// use case
Deprecate::1.3.6.1.4.1.19376.1.6.2.10.9.1[version="1.1.2"]

// profile
Deprecate::1.3.6.1.4.1.19376.1.6.2.10.2.11[version="1.1.2"]

// content module
Deprecate::1.3.6.1.4.1.19376.1.6.2.10.8.1[version="1.1.2"]
```

The `version` attribute is required. It gives the document version (see [`sdpi-standard.adoc`](https://github.com/IHE/DEV.SDPi/blob/master/asciidoc/sdpi-standard.adoc)) when the OID was first no longer available. Format is: `<sdpi_version_major>.<sdpi_version_minor>.<sdpi_version_revision>`. 

Deprecated requirements and transactions are exported to `sdpi-requirements-deprecated.json` and
`sdpi-transactions-deprecated.json`, respectively. All deprecated oids (including transactions and
requirements) are exported to `sdpi-deprecated.json` for reference. 

## ☑ Mandatory Tasks

The following aspects have been respected by the pull request assignee and at least one reviewer:
  
- Changelog update (necessity checked and entry added or not added respectively)
  * [x] Pull Request Assignee
  * [x] Reviewer
